### PR TITLE
Add proxy functionality. Re-enable local conf.

### DIFF
--- a/app/navigate-server/src/main/resources/conf/app.conf
+++ b/app/navigate-server/src/main/resources/conf/app.conf
@@ -37,6 +37,8 @@ web-server {
     insecure-port = 7071
     # External url used for redirects
     external-base-url = "navigate.hi.gemini.edu"
+    # Uri to forward requests made to /proxy to.
+    proxy-base-uri = "https://localhost:8080"
 }
 
 # Configuration of the navigate engine

--- a/modules/model/jvm/src/main/scala/navigate/model/config/WebServerConfiguration.scala
+++ b/modules/model/jvm/src/main/scala/navigate/model/config/WebServerConfiguration.scala
@@ -4,6 +4,7 @@
 package navigate.model.config
 
 import cats.Eq
+import org.http4s.Uri
 
 import java.nio.file.Path
 
@@ -43,7 +44,8 @@ case class WebServerConfiguration(
   host:            String,
   port:            Int,
   insecurePort:    Int,
-  externalBaseUrl: String
+  externalBaseUrl: String,
+  proxyBaseUri:    Uri
 ) {
   // FIXME Pureconfig can't load this anymore
   val tls: Option[TLSConfig] = None

--- a/modules/web/server/src/main/resources/app.conf
+++ b/modules/web/server/src/main/resources/app.conf
@@ -37,6 +37,8 @@ web-server {
     insecure-port = 7071
     # External url used for redirects
     external-base-url = "localhost"
+    # Uri to forward requests made to /proxy to.
+    proxy-base-uri = "https://localhost:8080"
 }
 
 # Configuration of the navigate engine

--- a/modules/web/server/src/main/scala/navigate/web/server/http4s/ProxyBuilder.scala
+++ b/modules/web/server/src/main/scala/navigate/web/server/http4s/ProxyBuilder.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.web.server.http4s
+
+import cats.data.OptionT
+import cats.effect.Async
+import cats.effect.kernel.Resource
+import cats.syntax.all.*
+import fs2.io.net.Network
+import org.http4s.HttpRoutes
+import org.http4s.Uri
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.headers._
+
+object ProxyBuilder:
+  def buildService[F[_]: Async: Network](
+    baseUri:   Uri,
+    localPath: Uri.Path
+  ): Resource[F, HttpRoutes[F]] =
+    val remoteBaseHost: String = baseUri.host.map(_.toString).orEmpty
+    val localPathElements: Int = localPath.segments.length
+
+    EmberClientBuilder
+      .default[F]
+      .build
+      .map(
+        _.toHttpApp
+          .mapK(OptionT.liftK) // Turns HttpApp into HttpRoutes
+          .local: req =>
+            req
+              .withUri(
+                // Drop the local path (eg: "/proxy")
+                baseUri.resolve(req.uri.withPath(req.uri.path.splitAt(localPathElements)._2))
+              )
+              .putHeaders(Host(remoteBaseHost))
+      )


### PR DESCRIPTION
The UI needs to connect to a second server, which provides an API to connect directly to Navigate's DB.

We can either:
1) Open the server's port to the world.
2) Deploy static files through an nginx server, and configure it as a proxy to both servers.
3) Have the existing server act as a proxy to the other server.

This PR implements option #3. Requests made to `/db/*` will be forwarded to the other server, stripping `/db`. The other server's base URI is configurable in `app.conf`.

Additionally, it reinstantes correctly reading `app.conf` from `resources` in development. This was broken when I implemented packaging.