### PR TITLE
OIWFS signal processing setup

### DIFF
--- a/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
+++ b/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
@@ -430,6 +430,25 @@ object NavigateEngine {
     guideConfig = GuideConfig.defaultGuideConfig
   )
 
+  /**
+   * This is used for simple commands, just an F that executes the command when evaluated, producing
+   * a result. The method takes care of setting/releasing guard flags in the global state and
+   * surrounding the evaluation with log messages. An important distinction with the new command
+   * method is that here, the command code does not have access to the global state.
+   *
+   * @param engine
+   *   The state machine.
+   * @param cmdType:
+   *   The command type, used for logs.
+   * @param cmd:
+   *   The actual command, wrapped in effect F.
+   * @param f:
+   *   Lens to the command guard flag in the global state.
+   * @tparam F:
+   *   Type of effect that wraps the command execution.
+   * @return
+   *   Effect that, when evaluated, will schedule the execution of the command in the state machine.
+   */
   private def simpleCommand[F[_]: MonadThrow: Logger](
     engine:  StateEngine[F, State, NavigateEvent],
     cmdType: NavigateCommand,
@@ -464,6 +483,23 @@ object NavigateEngine {
     }
   )
 
+  /**
+   * Similar to simple command, but here the command is a Handler, executed in the state machine.
+   * This gives the command access to the global state, and allows it to have several stages.
+   * @param engine
+   *   The state machine.
+   * @param cmdType:
+   *   The command type, used for logs.
+   * @param cmd:
+   *   The actual command, wrapped in a Handle. The command is responsible for generating the Stream
+   *   for later scheduling, although there is a helper method for that: transformCommand
+   * @param f:
+   *   Lens to the command guard flag in the global state.
+   * @tparam F:
+   *   Type of effect that wraps the command execution.
+   * @return
+   *   Effect that, when evaluated, will schedule the execution of the command in the state machine.
+   */
   private def command[F[_]: MonadThrow: Logger](
     engine:  StateEngine[F, State, NavigateEvent],
     cmdType: NavigateCommand,

--- a/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
+++ b/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
@@ -14,13 +14,17 @@ import cats.syntax.all.*
 import fs2.Pipe
 import fs2.Stream
 import io.circe.syntax.*
+import lucuma.core.enums.MountGuideOption
 import lucuma.core.enums.Site
 import lucuma.core.math.Angle
 import lucuma.core.model.GuideConfig
+import lucuma.core.model.M1GuideConfig
+import lucuma.core.model.M2GuideConfig
 import lucuma.core.model.TelescopeGuideConfig
 import lucuma.core.util.TimeSpan
 import monocle.Focus
 import monocle.Lens
+import monocle.syntax.all.focus
 import navigate.model.NavigateCommand
 import navigate.model.NavigateCommand.*
 import navigate.model.NavigateEvent
@@ -39,7 +43,9 @@ import navigate.server.tcs.SlewOptions
 import navigate.server.tcs.Target
 import navigate.server.tcs.TcsBaseController.TcsConfig
 import navigate.server.tcs.TrackingConfig
+import navigate.stateengine.Handler
 import navigate.stateengine.StateEngine
+import navigate.stateengine.StateEngine.Event
 import org.http4s.EntityDecoder
 import org.http4s.*
 import org.http4s.circe.*
@@ -155,37 +161,37 @@ object NavigateEngine {
       engine.process(startState)
 
     override def mcsPark: F[Unit] =
-      command(engine, McsPark, systems.tcsSouth.mcsPark, Focus[State](_.mcsParkInProgress))
+      simpleCommand(engine, McsPark, systems.tcsSouth.mcsPark, Focus[State](_.mcsParkInProgress))
 
     override def mcsFollow(enable: Boolean): F[Unit] =
-      command(engine,
-              McsFollow(enable),
-              systems.tcsSouth.mcsFollow(enable),
-              Focus[State](_.mcsFollowInProgress)
+      simpleCommand(engine,
+                    McsFollow(enable),
+                    systems.tcsSouth.mcsFollow(enable),
+                    Focus[State](_.mcsFollowInProgress)
       )
 
     override def rotStop(useBrakes: Boolean): F[Unit] =
-      command(engine,
-              CrcsStop(useBrakes),
-              systems.tcsSouth.rotStop(useBrakes),
-              Focus[State](_.rotStopInProgress)
+      simpleCommand(engine,
+                    CrcsStop(useBrakes),
+                    systems.tcsSouth.rotStop(useBrakes),
+                    Focus[State](_.rotStopInProgress)
       )
 
     override def rotPark: F[Unit] =
-      command(engine, CrcsPark, systems.tcsSouth.rotPark, Focus[State](_.rotParkInProgress))
+      simpleCommand(engine, CrcsPark, systems.tcsSouth.rotPark, Focus[State](_.rotParkInProgress))
 
     override def rotFollow(enable: Boolean): F[Unit] =
-      command(engine,
-              CrcsFollow(enable),
-              systems.tcsSouth.rotFollow(enable),
-              Focus[State](_.rotFollowInProgress)
+      simpleCommand(engine,
+                    CrcsFollow(enable),
+                    systems.tcsSouth.rotFollow(enable),
+                    Focus[State](_.rotFollowInProgress)
       )
 
     override def rotMove(angle: Angle): F[Unit] =
-      command(engine,
-              CrcsMove(angle),
-              systems.tcsSouth.rotMove(angle),
-              Focus[State](_.rotMoveInProgress)
+      simpleCommand(engine,
+                    CrcsMove(angle),
+                    systems.tcsSouth.rotMove(angle),
+                    Focus[State](_.rotMoveInProgress)
       )
 
     override def ecsCarouselMode(
@@ -194,7 +200,7 @@ object NavigateEngine {
       slitHeight:    Double,
       domeEnable:    Boolean,
       shutterEnable: Boolean
-    ): F[Unit] = command(
+    ): F[Unit] = simpleCommand(
       engine,
       EcsCarouselMode(domeMode, shutterMode, slitHeight, domeEnable, shutterEnable),
       systems.tcsSouth.ecsCarouselMode(domeMode,
@@ -209,14 +215,14 @@ object NavigateEngine {
     // TODO
     override def ecsVentGatesMove(gateEast: Double, westGate: Double): F[Unit] = Applicative[F].unit
 
-    override def tcsConfig(config: TcsConfig): F[Unit] = command(
+    override def tcsConfig(config: TcsConfig): F[Unit] = simpleCommand(
       engine,
       TcsConfigure,
       systems.tcsSouth.tcsConfig(config),
       Focus[State](_.tcsConfigInProgress)
     )
 
-    override def slew(slewOptions: SlewOptions, tcsConfig: TcsConfig): F[Unit] = command(
+    override def slew(slewOptions: SlewOptions, tcsConfig: TcsConfig): F[Unit] = simpleCommand(
       engine,
       Slew,
       systems.tcsSouth.slew(slewOptions, tcsConfig),
@@ -224,70 +230,114 @@ object NavigateEngine {
     )
 
     override def instrumentSpecifics(instrumentSpecificsParams: InstrumentSpecifics): F[Unit] =
-      command(
+      simpleCommand(
         engine,
         InstSpecifics,
         systems.tcsSouth.instrumentSpecifics(instrumentSpecificsParams),
         Focus[State](_.instrumentSpecificsInProgress)
       )
 
-    override def oiwfsTarget(target: Target): F[Unit] = command(
+    override def oiwfsTarget(target: Target): F[Unit] = simpleCommand(
       engine,
       OiwfsTarget,
       systems.tcsSouth.oiwfsTarget(target),
       Focus[State](_.oiwfsInProgress)
     )
 
-    override def oiwfsProbeTracking(config: TrackingConfig): F[Unit] = command(
+    override def oiwfsProbeTracking(config: TrackingConfig): F[Unit] = simpleCommand(
       engine,
       OiwfsProbeTracking,
       systems.tcsSouth.oiwfsProbeTracking(config),
       Focus[State](_.oiwfsProbeTrackingInProgress)
     )
 
-    override def oiwfsPark: F[Unit] = command(
+    override def oiwfsPark: F[Unit] = simpleCommand(
       engine,
       OiwfsPark,
       systems.tcsSouth.oiwfsPark,
       Focus[State](_.oiwfsParkInProgress)
     )
 
-    override def oiwfsFollow(enable: Boolean): F[Unit] = command(
+    override def oiwfsFollow(enable: Boolean): F[Unit] = simpleCommand(
       engine,
       OiwfsFollow(enable),
       systems.tcsSouth.oiwfsFollow(enable),
       Focus[State](_.oiwfsFollowInProgress)
     )
 
-    override def rotTrackingConfig(cfg: navigate.server.tcs.RotatorTrackConfig): F[Unit] = command(
-      engine,
-      RotatorTrackingConfig,
-      systems.tcsSouth.rotTrackingConfig(cfg),
-      Focus[State](_.rotTrackingConfigInProgress)
-    )
+    override def rotTrackingConfig(cfg: navigate.server.tcs.RotatorTrackConfig): F[Unit] =
+      simpleCommand(
+        engine,
+        RotatorTrackingConfig,
+        systems.tcsSouth.rotTrackingConfig(cfg),
+        Focus[State](_.rotTrackingConfigInProgress)
+      )
 
-    override def enableGuide(config: TelescopeGuideConfig): F[Unit] = command(
-      engine,
-      EnableGuide,
-      systems.tcsSouth.enableGuide(config),
-      Focus[State](_.enableGuide)
-    ) *> postTelescopeGuideConfig(GuideConfig(config, None))
+    override def enableGuide(config: TelescopeGuideConfig): F[Unit] =
+      command(
+        engine,
+        EnableGuide,
+        transformCommand(
+          EnableGuide,
+          Handler.get[F, State, ApplyCommandResult].flatMap { st =>
+            Handler.replace(st.focus(_.guideConfig.tcsGuide).replace(config)) *>
+              Handler.fromStream(
+                Stream.eval(
+                  systems.tcsSouth.enableGuide(config)
+                )
+              )
+          },
+          Focus[State](_.enableGuide)
+        ),
+        Focus[State](_.enableGuide)
+      ) *> postTelescopeGuideConfig(GuideConfig(config, None))
 
     override def disableGuide: F[Unit] = command(
       engine,
       DisableGuide,
-      systems.tcsSouth.disableGuide,
+      transformCommand(
+        DisableGuide,
+        Handler.get[F, State, ApplyCommandResult].flatMap { st =>
+          Handler.replace[F, State, ApplyCommandResult](
+            st.focus(_.guideConfig.tcsGuide)
+              .replace(
+                TelescopeGuideConfig(MountGuideOption.MountGuideOff,
+                                     M1GuideConfig.M1GuideOff,
+                                     M2GuideConfig.M2GuideOff,
+                                     None,
+                                     None
+                )
+              )
+          ) *>
+            Handler.fromStream(
+              Stream.eval(
+                systems.tcsSouth.disableGuide
+              )
+            )
+        },
+        Focus[State](_.disableGuide)
+      ),
       Focus[State](_.disableGuide)
     ) *> postTelescopeGuideConfig(GuideConfig.defaultGuideConfig)
 
     override def oiwfsObserve(period: TimeSpan): F[Unit] = command(
       engine,
       OiwfsObserve,
-      systems.tcsSouth.oiwfsObserve(period, false),
+      transformCommand(
+        OiwfsObserve,
+        Handler.get[F, State, ApplyCommandResult].flatMap { st =>
+          Handler.fromStream(
+            Stream.eval(
+              systems.tcsSouth.oiwfsObserve(period)
+            )
+          )
+        },
+        Focus[State](_.oiwfsObserve)
+      ),
       Focus[State](_.oiwfsObserve)
     )
 
-    override def oiwfsStopObserve: F[Unit] = command(
+    override def oiwfsStopObserve: F[Unit] = simpleCommand(
       engine,
       OiwfsStopObserve,
       systems.tcsSouth.oiwfsStopObserve,
@@ -304,6 +354,11 @@ object NavigateEngine {
   ): F[NavigateEngine[F]] = StateEngine
     .build[F, State, NavigateEvent]
     .map(NavigateEngineImpl[F](site, systems, conf, _))
+
+  case class WfsConfigState(
+    period:          Option[TimeSpan],
+    configuredForQl: Option[Boolean]
+  )
 
   case class State(
     mcsParkInProgress:             Boolean,
@@ -325,7 +380,8 @@ object NavigateEngine {
     enableGuide:                   Boolean,
     disableGuide:                  Boolean,
     oiwfsObserve:                  Boolean,
-    oiwfsStopObserve:              Boolean
+    oiwfsStopObserve:              Boolean,
+    guideConfig:                   GuideConfig
   ) {
     lazy val tcsActionInProgress: Boolean =
       mcsParkInProgress ||
@@ -370,10 +426,11 @@ object NavigateEngine {
     enableGuide = false,
     disableGuide = false,
     oiwfsObserve = false,
-    oiwfsStopObserve = false
+    oiwfsStopObserve = false,
+    guideConfig = GuideConfig.defaultGuideConfig
   )
 
-  private def command[F[_]: MonadThrow: Logger](
+  private def simpleCommand[F[_]: MonadThrow: Logger](
     engine:  StateEngine[F, State, NavigateEvent],
     cmdType: NavigateCommand,
     cmd:     F[ApplyCommandResult],
@@ -383,23 +440,20 @@ object NavigateEngine {
       if (!st.tcsActionInProgress) {
         engine
           .modifyState(f.replace(true))
-          .as(CommandStart(cmdType)) *>
-          engine.lift(
-            Logger[F].info(s"Start command ${cmdType.name}") *>
-              cmd.attempt
-                .map {
-                  case Right(ApplyCommandResult.Paused)    => CommandPaused(cmdType)
-                  case Right(ApplyCommandResult.Completed) => CommandSuccess(cmdType)
-                  case Left(e)                             =>
-                    CommandFailure(cmdType,
-                                   s"${cmdType.name} command failed with error: ${e.getMessage}"
+          .as(CommandStart(cmdType).some) <*
+          Handler
+            .fromStream[F, State, Event[F, State, NavigateEvent]](
+              Stream.eval[F, Event[F, State, NavigateEvent]](
+                Logger[F].info(s"Start command ${cmdType.name}") *>
+                  cmd.attempt
+                    .map(cmdResultToNavigateEvent(cmdType, _))
+                    .flatMap(x =>
+                      Logger[F]
+                        .info(s"Command ${cmdType.name} ended with result $x")
+                        .as(Event(engine.modifyState(f.replace(false)).as(x.some)))
                     )
-                }
-                .flatMap { x =>
-                  Logger[F].info(s"Command ${cmdType.name} ended with result $x").as(x)
-                }
-          ) <*
-          engine.modifyState(f.replace(false))
+              )
+            )
       } else {
         engine.lift(
           Logger[F]
@@ -409,5 +463,66 @@ object NavigateEngine {
       }
     }
   )
+
+  private def command[F[_]: MonadThrow: Logger](
+    engine:  StateEngine[F, State, NavigateEvent],
+    cmdType: NavigateCommand,
+    cmd:     Handler[F, State, Event[F, State, NavigateEvent], Unit],
+    f:       Lens[State, Boolean]
+  ): F[Unit] = engine.offer(
+    engine.getState.flatMap { st =>
+      if (!st.tcsActionInProgress) {
+        engine
+          .modifyState(f.replace(true))
+          .as(CommandStart(cmdType).some) <* cmd
+      } else {
+        engine.lift(
+          Logger[F]
+            .warn(s"Cannot execute command ${cmdType.name} because a TCS command is in progress.")
+            .as(NullEvent)
+        ) *> engine.void
+      }
+    }
+  )
+
+  private def cmdResultToNavigateEvent(
+    cmdType: NavigateCommand,
+    result:  Either[Throwable, ApplyCommandResult]
+  ): NavigateEvent =
+    result match {
+      case Right(ApplyCommandResult.Paused)    => CommandPaused(cmdType)
+      case Right(ApplyCommandResult.Completed) => CommandSuccess(cmdType)
+      case Left(e)                             =>
+        CommandFailure(cmdType, s"${cmdType.name} command failed with error: ${e.getMessage}")
+    }
+
+  private def transformCommand[F[_]: MonadThrow: Logger](
+    cmdType: NavigateCommand,
+    cmd:     Handler[F, State, ApplyCommandResult, Unit],
+    f:       Lens[State, Boolean]
+  ): Handler[F, State, Event[F, State, NavigateEvent], Unit] =
+    Handler(cmd.run.map { ret =>
+      Handler.RetVal(
+        ret.v,
+        ret.s.map { ss =>
+          Stream.eval(
+            Logger[F].info(s"Start command ${cmdType.name}")
+          ) *>
+            ss.attempt.map(cmdResultToNavigateEvent(cmdType, _)).flatMap { x =>
+              Stream.eval(
+                Logger[F]
+                  .info(s"Command ${cmdType.name} ended with result $x")
+                  .as(
+                    Event(
+                      Handler
+                        .modify[F, State, Event[F, State, NavigateEvent]](f.replace(false))
+                        .as(x.some)
+                    )
+                  )
+              )
+            }
+        }
+      )
+    })
 
 }

--- a/modules/server/src/main/scala/navigate/server/Systems.scala
+++ b/modules/server/src/main/scala/navigate/server/Systems.scala
@@ -8,8 +8,8 @@ import cats.effect.Async
 import cats.effect.Resource
 import cats.effect.std.Dispatcher
 import cats.syntax.all.*
-import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.Site
+import lucuma.refined.*
 import navigate.epics.EpicsService
 import navigate.model.config.ControlStrategy
 import navigate.model.config.NavigateEngineConfiguration
@@ -41,18 +41,12 @@ object Systems {
       if (conf.systemControl.tcs === ControlStrategy.FullControl)
         for {
           tcs <- TcsEpicsSystem.build(epicsSrv, tops)
-          p1  <- WfsEpicsSystem.build(epicsSrv,
-                                      "PWFS1",
-                                      readTop(tops, NonEmptyString.unsafeFrom("pwfs1"))
-                 )
-          p2  <- WfsEpicsSystem.build(epicsSrv,
-                                      "PWFS2",
-                                      readTop(tops, NonEmptyString.unsafeFrom("pwfs2"))
-                 )
+          p1  <- WfsEpicsSystem.build(epicsSrv, "PWFS1", readTop(tops, "pwfs1".refined))
+          p2  <- WfsEpicsSystem.build(epicsSrv, "PWFS2", readTop(tops, "pwfs2".refined))
           oi  <- WfsEpicsSystem.build(epicsSrv,
                                       "OIWFS",
-                                      readTop(tops, NonEmptyString.unsafeFrom("oiwfs")),
-                                      NonEmptyString.unsafeFrom("dc:initSigInit.MARK")
+                                      readTop(tops, "oiwfs".refined),
+                                      "dc:initSigInit.MARK".refined
                  )
           r   <- Resource.eval(TcsSouthControllerEpics.build(tcs, p1, p2, oi, conf.ioTimeout))
         } yield r
@@ -63,18 +57,12 @@ object Systems {
       if (conf.systemControl.tcs === ControlStrategy.FullControl)
         for {
           tcs <- TcsEpicsSystem.build(epicsSrv, tops)
-          p1  <- WfsEpicsSystem.build(epicsSrv,
-                                      "PWFS1",
-                                      readTop(tops, NonEmptyString.unsafeFrom("pwfs1"))
-                 )
-          p2  <- WfsEpicsSystem.build(epicsSrv,
-                                      "PWFS2",
-                                      readTop(tops, NonEmptyString.unsafeFrom("pwfs2"))
-                 )
+          p1  <- WfsEpicsSystem.build(epicsSrv, "PWFS1", readTop(tops, "pwfs1".refined))
+          p2  <- WfsEpicsSystem.build(epicsSrv, "PWFS2", readTop(tops, "pwfs2".refined))
           oi  <- WfsEpicsSystem.build(epicsSrv,
                                       "OIWFS",
-                                      readTop(tops, NonEmptyString.unsafeFrom("oiwfs")),
-                                      NonEmptyString.unsafeFrom("dc:initSigInit.MARK")
+                                      readTop(tops, "oiwfs".refined),
+                                      "dc:initSigInit.MARK".refined
                  )
           r   <- Resource.eval(TcsNorthControllerEpics.build(tcs, p1, p2, oi, conf.ioTimeout))
         } yield r

--- a/modules/server/src/main/scala/navigate/server/Systems.scala
+++ b/modules/server/src/main/scala/navigate/server/Systems.scala
@@ -54,7 +54,8 @@ object Systems {
                                       readTop(tops, NonEmptyString.unsafeFrom("oiwfs")),
                                       NonEmptyString.unsafeFrom("dc:initSigInit.MARK")
                  )
-        } yield new TcsSouthControllerEpics(tcs, p1, p2, oi, conf.ioTimeout)
+          r   <- Resource.eval(TcsSouthControllerEpics.build(tcs, p1, p2, oi, conf.ioTimeout))
+        } yield r
       else
         Resource.eval(TcsSouthControllerSim.build)
 
@@ -75,7 +76,8 @@ object Systems {
                                       readTop(tops, NonEmptyString.unsafeFrom("oiwfs")),
                                       NonEmptyString.unsafeFrom("dc:initSigInit.MARK")
                  )
-        } yield new TcsNorthControllerEpics(tcs, p1, p2, oi, conf.ioTimeout)
+          r   <- Resource.eval(TcsNorthControllerEpics.build(tcs, p1, p2, oi, conf.ioTimeout))
+        } yield r
       else
         Resource.eval(TcsNorthControllerSim.build)
 

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseController.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseController.scala
@@ -38,7 +38,7 @@ trait TcsBaseController[F[_]] {
   def oiwfsFollow(enable:         Boolean): F[ApplyCommandResult]
   def enableGuide(config:         TelescopeGuideConfig): F[ApplyCommandResult]
   def disableGuide: F[ApplyCommandResult]
-  def oiwfsObserve(exposureTime:  TimeSpan, isQL:         Boolean): F[ApplyCommandResult]
+  def oiwfsObserve(exposureTime:  TimeSpan): F[ApplyCommandResult]
   def oiwfsStopObserve: F[ApplyCommandResult]
 
   def getGuideState: F[GuideState]

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
@@ -91,7 +91,7 @@ class TcsBaseControllerSim[F[_]: Applicative](guideRef: Ref[F, GuideState])
     )
     .as(ApplyCommandResult.Completed)
 
-  override def oiwfsObserve(exposureTime: TimeSpan, isQL: Boolean): F[ApplyCommandResult] = guideRef
+  override def oiwfsObserve(exposureTime: TimeSpan): F[ApplyCommandResult] = guideRef
     .update(_.copy(oiIntegrating = true))
     .as(ApplyCommandResult.Completed)
 

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsChannels.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsChannels.scala
@@ -46,7 +46,6 @@ case class TcsChannels[F[_]](
   mountGuide:       MountGuideChannels[F],
   oiwfs:            WfsChannels[F],
   guide:            GuideConfigStatusChannels[F],
-  // guiderGains:      GuiderGainsChannels[F],
   probeGuideMode:   ProbeGuideModeChannels[F],
   oiwfsSelect:      OiwfsSelectChannels[F]
 )

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsNorthControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsNorthControllerEpics.scala
@@ -10,6 +10,9 @@ import scala.concurrent.duration.FiniteDuration
 
 class TcsNorthControllerEpics[F[_]: Async: Parallel](
   tcsEpics: TcsEpicsSystem[F],
+  pwfs1:    WfsEpicsSystem[F],
+  pwfs2:    WfsEpicsSystem[F],
+  oiwfs:    WfsEpicsSystem[F],
   timeout:  FiniteDuration
-) extends TcsBaseControllerEpics[F](tcsEpics, timeout)
+) extends TcsBaseControllerEpics[F](tcsEpics, pwfs1, pwfs2, oiwfs, timeout)
     with TcsNorthController[F] {}

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerEpics.scala
@@ -10,6 +10,9 @@ import scala.concurrent.duration.FiniteDuration
 
 class TcsSouthControllerEpics[F[_]: Async: Parallel](
   tcsEpics: TcsEpicsSystem[F],
+  pwfs1:    WfsEpicsSystem[F],
+  pwfs2:    WfsEpicsSystem[F],
+  oiwfs:    WfsEpicsSystem[F],
   timeout:  FiniteDuration
-) extends TcsBaseControllerEpics[F](tcsEpics, timeout)
+) extends TcsBaseControllerEpics[F](tcsEpics, pwfs1, pwfs2, oiwfs, timeout)
     with TcsSouthController[F] {}

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerEpics.scala
@@ -5,6 +5,8 @@ package navigate.server.tcs
 
 import cats.Parallel
 import cats.effect.Async
+import cats.effect.Ref
+import cats.syntax.all.*
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -13,6 +15,24 @@ class TcsSouthControllerEpics[F[_]: Async: Parallel](
   pwfs1:    WfsEpicsSystem[F],
   pwfs2:    WfsEpicsSystem[F],
   oiwfs:    WfsEpicsSystem[F],
-  timeout:  FiniteDuration
-) extends TcsBaseControllerEpics[F](tcsEpics, pwfs1, pwfs2, oiwfs, timeout)
+  timeout:  FiniteDuration,
+  stateRef: Ref[F, TcsBaseControllerEpics.State]
+) extends TcsBaseControllerEpics[F](tcsEpics, pwfs1, pwfs2, oiwfs, timeout, stateRef)
     with TcsSouthController[F] {}
+
+object TcsSouthControllerEpics {
+
+  def build[F[_]: Async: Parallel](
+    tcsEpics: TcsEpicsSystem[F],
+    pwfs1:    WfsEpicsSystem[F],
+    pwfs2:    WfsEpicsSystem[F],
+    oiwfs:    WfsEpicsSystem[F],
+    timeout:  FiniteDuration
+  ): F[TcsSouthControllerEpics[F]] =
+    Ref
+      .of[F, TcsBaseControllerEpics.State](TcsBaseControllerEpics.State.default)
+      .map(
+        new TcsSouthControllerEpics(tcsEpics, pwfs1, pwfs2, oiwfs, timeout, _)
+      )
+
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/WfsChannels.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/WfsChannels.scala
@@ -13,30 +13,30 @@ import navigate.server.acm.CadDirective
 import navigate.server.epicsdata.BinaryYesNo
 
 case class WfsChannels[F[_]](
-  telltale: TelltaleChannel[F],
-  tipGain: Channel[F, String],
-  tiltGain: Channel[F, String],
+  telltale:  TelltaleChannel[F],
+  tipGain:   Channel[F, String],
+  tiltGain:  Channel[F, String],
   focusGain: Channel[F, String],
-  reset: Channel[F, BinaryYesNo],
-  gainsDir: Channel[F, CadDirective],
-  resetDir: Channel[F, CadDirective]
+  reset:     Channel[F, BinaryYesNo],
+  gainsDir:  Channel[F, CadDirective],
+  resetDir:  Channel[F, CadDirective]
 )
 
 object WfsChannels {
   def build[F[_]](
-    service:  EpicsService[F],
-    sysName: String,
-    top: NonEmptyString,
+    service:      EpicsService[F],
+    sysName:      String,
+    top:          NonEmptyString,
     telltaleName: NonEmptyString
   ): Resource[F, WfsChannels[F]] =
     for {
-      tell <- service.getChannel[String](top, telltaleName.value).map(TelltaleChannel(sysName, _))
-      tipG <- service.getChannel[String](top, "dc:detSigInitFgGain.A")
-      tiltG <- service.getChannel[String](top, "dc:detSigInitFgGain.B")
+      tell   <- service.getChannel[String](top, telltaleName.value).map(TelltaleChannel(sysName, _))
+      tipG   <- service.getChannel[String](top, "dc:detSigInitFgGain.A")
+      tiltG  <- service.getChannel[String](top, "dc:detSigInitFgGain.B")
       focusG <- service.getChannel[String](top, "dc:detSigInitFgGain.C")
-      gDir <- service.getChannel[CadDirective](top, "dc:detSigInitFgGain.DIR")
-      rst <- service.getChannel[BinaryYesNo](top, "dc:initSigInit.J")
-      rDir <- service.getChannel[CadDirective](top, "dc:initSigInit.DIR")
+      gDir   <- service.getChannel[CadDirective](top, "dc:detSigInitFgGain.DIR")
+      rst    <- service.getChannel[BinaryYesNo](top, "dc:initSigInit.J")
+      rDir   <- service.getChannel[CadDirective](top, "dc:initSigInit.DIR")
     } yield WfsChannels[F](
       telltale = tell,
       tipGain = tipG,
@@ -45,5 +45,5 @@ object WfsChannels {
       reset = rst,
       gainsDir = gDir,
       resetDir = rDir
-  )
+    )
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/WfsChannels.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/WfsChannels.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.effect.Resource
+import eu.timepit.refined.types.string.NonEmptyString
+import navigate.epics.Channel
+import navigate.epics.EpicsService
+import navigate.epics.EpicsSystem.TelltaleChannel
+import navigate.epics.given
+import navigate.server.acm.CadDirective
+import navigate.server.epicsdata.BinaryYesNo
+
+case class WfsChannels[F[_]](
+  telltale: TelltaleChannel[F],
+  tipGain: Channel[F, String],
+  tiltGain: Channel[F, String],
+  focusGain: Channel[F, String],
+  reset: Channel[F, BinaryYesNo],
+  gainsDir: Channel[F, CadDirective],
+  resetDir: Channel[F, CadDirective]
+)
+
+object WfsChannels {
+  def build[F[_]](
+    service:  EpicsService[F],
+    sysName: String,
+    top: NonEmptyString,
+    telltaleName: NonEmptyString
+  ): Resource[F, WfsChannels[F]] =
+    for {
+      tell <- service.getChannel[String](top, telltaleName.value).map(TelltaleChannel(sysName, _))
+      tipG <- service.getChannel[String](top, "dc:detSigInitFgGain.A")
+      tiltG <- service.getChannel[String](top, "dc:detSigInitFgGain.B")
+      focusG <- service.getChannel[String](top, "dc:detSigInitFgGain.C")
+      gDir <- service.getChannel[CadDirective](top, "dc:detSigInitFgGain.DIR")
+      rst <- service.getChannel[BinaryYesNo](top, "dc:initSigInit.J")
+      rDir <- service.getChannel[CadDirective](top, "dc:initSigInit.DIR")
+    } yield WfsChannels[F](
+      telltale = tell,
+      tipGain = tipG,
+      tiltGain = tiltG,
+      focusGain = focusG,
+      reset = rst,
+      gainsDir = gDir,
+      resetDir = rDir
+  )
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/WfsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/WfsEpicsSystem.scala
@@ -10,6 +10,7 @@ import cats.effect.Temporal
 import cats.effect.std.Dispatcher
 import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.refined.*
 import navigate.epics.EpicsService
 import navigate.epics.VerifiedEpics
 import navigate.epics.VerifiedEpics.VerifiedEpics
@@ -52,7 +53,7 @@ object WfsEpicsSystem {
     service:             EpicsService[F],
     sysName:             String,
     top:                 NonEmptyString,
-    telltaleChannelName: NonEmptyString = NonEmptyString.unsafeFrom("health.VAL")
+    telltaleChannelName: NonEmptyString = "health.VAL".refined
   ): Resource[F, WfsEpicsSystem[F]] = for {
     channels <- WfsChannels.build(service, sysName, top, telltaleChannelName)
   } yield buildSystem(channels)

--- a/modules/server/src/main/scala/navigate/server/tcs/WfsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/WfsEpicsSystem.scala
@@ -1,0 +1,111 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.Monad
+import cats.Parallel
+import cats.effect.Resource
+import cats.effect.Temporal
+import cats.effect.std.Dispatcher
+import cats.syntax.all.*
+import eu.timepit.refined.types.string.NonEmptyString
+import navigate.epics.EpicsService
+import navigate.epics.VerifiedEpics
+import navigate.epics.VerifiedEpics.VerifiedEpics
+import navigate.epics.VerifiedEpics._
+import navigate.server.ApplyCommandResult
+import navigate.server.acm.CadDirective
+import navigate.server.acm.ParameterList.*
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+
+trait WfsEpicsSystem[F[_]] {
+  def startCommand(timeout: FiniteDuration): WfsEpicsSystem.WfsCommands[F]
+}
+
+object WfsEpicsSystem {
+
+  trait WfsCommands[F[_]] {
+    def post: VerifiedEpics[F, F, ApplyCommandResult]
+    val gains: GainsCommand[F, WfsCommands[F]]
+  }
+
+  trait GainsCommand[F[_], +S] {
+    def setTipGain(v:   Double): S
+    def setTiltGain(v:  Double): S
+    def setFocusGain(v: Double): S
+  }
+
+  private[tcs] def buildSystem[F[_]: Monad: Temporal: Parallel](
+    channels: WfsChannels[F]
+  ): WfsEpicsSystem[F] = new WfsEpicsSystem[F] {
+    override def startCommand(timeout: FiniteDuration): WfsCommands[F] =
+      new WfsCommandsImpl[F](
+        new WfsEpicsImpl[F](channels),
+        timeout
+      )
+  }
+
+  def build[F[_]: Dispatcher: Temporal: Parallel](
+    service:             EpicsService[F],
+    sysName:             String,
+    top:                 NonEmptyString,
+    telltaleChannelName: NonEmptyString = NonEmptyString.unsafeFrom("health.VAL")
+  ): Resource[F, WfsEpicsSystem[F]] = for {
+    channels <- WfsChannels.build(service, sysName, top, telltaleChannelName)
+  } yield buildSystem(channels)
+
+  trait WfsEpics[F[_]] {
+    def post(timeout: FiniteDuration): VerifiedEpics[F, F, ApplyCommandResult]
+    val gainsCmd: Command3Channels[F, Double, Double, Double]
+  }
+
+  // There is no CAR associated these commands. Without feedback, we can only wait and pray.
+  val commandWaitTime: FiniteDuration = FiniteDuration(500, TimeUnit.MILLISECONDS)
+
+  class WfsEpicsImpl[F[_]: Monad: Temporal](
+    channels: WfsChannels[F]
+  ) extends WfsEpics[F] {
+    override def post(timeout: FiniteDuration): VerifiedEpics[F, F, ApplyCommandResult] =
+      VerifiedEpics.writeChannel(channels.telltale, channels.gainsDir)(
+        CadDirective.START.pure[F]
+      ) *>
+        VerifiedEpics.writeChannel(channels.telltale, channels.resetDir)(
+          CadDirective.START.pure[F]
+        ) *>
+        VerifiedEpics.liftF(Temporal[F].sleep(commandWaitTime).as(ApplyCommandResult.Completed))
+
+    override val gainsCmd: Command3Channels[F, Double, Double, Double] =
+      Command3Channels[F, Double, Double, Double](
+        channels.telltale,
+        channels.tipGain,
+        channels.tiltGain,
+        channels.focusGain
+      )
+  }
+
+  private class WfsCommandsImpl[F[_]: Monad: Parallel](
+    wfsEpics: WfsEpics[F],
+    timeout:  FiniteDuration,
+    params:   ParameterList[F] = List.empty[VerifiedEpics[F, F, Unit]]
+  ) extends WfsCommands[F] {
+    private def addParam(p: VerifiedEpics[F, F, Unit]): WfsCommands[F] =
+      WfsCommandsImpl(wfsEpics, timeout, params :+ p)
+
+    override def post: VerifiedEpics[F, F, ApplyCommandResult] =
+      params.compile *> wfsEpics.post(timeout)
+
+    override val gains: GainsCommand[F, WfsCommands[F]] = new GainsCommand[F, WfsCommands[F]] {
+      override def setTipGain(v: Double): WfsCommands[F] = addParam(wfsEpics.gainsCmd.setParam1(v))
+
+      override def setTiltGain(v: Double): WfsCommands[F] = addParam(wfsEpics.gainsCmd.setParam2(v))
+
+      override def setFocusGain(v: Double): WfsCommands[F] = addParam(
+        wfsEpics.gainsCmd.setParam3(v)
+      )
+    }
+  }
+
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/package.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/package.scala
@@ -3,8 +3,17 @@
 
 package navigate.server.tcs
 
+import cats.Applicative
+import cats.Monad
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.util.NewType
+import navigate.epics.Channel
+import navigate.epics.EpicsSystem.TelltaleChannel
+import navigate.epics.VerifiedEpics.VerifiedEpics
+import navigate.epics.VerifiedEpics.writeChannel
+import navigate.server.acm.CadDirective
+import navigate.server.acm.Encoder
+import navigate.server.acm.writeCadParam
 
 object TcsTop extends NewType[NonEmptyString]
 type TcsTop = TcsTop.Type
@@ -16,3 +25,176 @@ object OiwfsTop extends NewType[NonEmptyString]
 type OiwfsTop = OiwfsTop.Type
 object AgTop extends NewType[NonEmptyString]
 type AgTop = AgTop.Type
+
+case class ParameterlessCommandChannels[F[_]: Monad](
+  tt:         TelltaleChannel[F],
+  dirChannel: Channel[F, CadDirective]
+) {
+  val mark: VerifiedEpics[F, F, Unit] =
+    writeChannel[F, CadDirective](tt, dirChannel)(Applicative[F].pure(CadDirective.MARK))
+}
+
+case class Command1Channels[F[_]: Monad, A: Encoder[*, String]](
+  tt:            TelltaleChannel[F],
+  param1Channel: Channel[F, String]
+) {
+  def setParam1(v: A): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, A](tt, param1Channel)(v)
+}
+
+case class Command2Channels[F[_]: Monad, A: Encoder[*, String], B: Encoder[*, String]](
+  tt:            TelltaleChannel[F],
+  param1Channel: Channel[F, String],
+  param2Channel: Channel[F, String]
+) {
+  def setParam1(v: A): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, A](tt, param1Channel)(v)
+
+  def setParam2(v: B): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, B](tt, param2Channel)(v)
+}
+
+case class Command3Channels[F[_]: Monad, A: Encoder[*, String], B: Encoder[*, String], C: Encoder[
+  *,
+  String
+]](
+  tt:            TelltaleChannel[F],
+  param1Channel: Channel[F, String],
+  param2Channel: Channel[F, String],
+  param3Channel: Channel[F, String]
+) {
+  def setParam1(v: A): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, A](tt, param1Channel)(v)
+
+  def setParam2(v: B): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, B](tt, param2Channel)(v)
+
+  def setParam3(v: C): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, C](tt, param3Channel)(v)
+}
+
+case class Command4Channels[F[_]: Monad, A: Encoder[*, String], B: Encoder[*, String], C: Encoder[
+  *,
+  String
+], D: Encoder[*, String]](
+  tt:            TelltaleChannel[F],
+  param1Channel: Channel[F, String],
+  param2Channel: Channel[F, String],
+  param3Channel: Channel[F, String],
+  param4Channel: Channel[F, String]
+) {
+  def setParam1(v: A): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, A](tt, param1Channel)(v)
+
+  def setParam2(v: B): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, B](tt, param2Channel)(v)
+
+  def setParam3(v: C): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, C](tt, param3Channel)(v)
+
+  def setParam4(v: D): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, D](tt, param4Channel)(v)
+}
+
+case class Command5Channels[F[_]: Monad, A: Encoder[*, String], B: Encoder[*, String], C: Encoder[
+  *,
+  String
+], D: Encoder[*, String], E: Encoder[*, String]](
+  tt:            TelltaleChannel[F],
+  param1Channel: Channel[F, String],
+  param2Channel: Channel[F, String],
+  param3Channel: Channel[F, String],
+  param4Channel: Channel[F, String],
+  param5Channel: Channel[F, String]
+) {
+  def setParam1(v: A): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, A](tt, param1Channel)(v)
+
+  def setParam2(v: B): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, B](tt, param2Channel)(v)
+
+  def setParam3(v: C): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, C](tt, param3Channel)(v)
+
+  def setParam4(v: D): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, D](tt, param4Channel)(v)
+
+  def setParam5(v: E): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, E](tt, param5Channel)(v)
+}
+
+case class Command6Channels[F[_]: Monad, A: Encoder[*, String], B: Encoder[*, String], C: Encoder[
+  *,
+  String
+], D: Encoder[*, String], E: Encoder[*, String], G: Encoder[*, String]](
+  tt:            TelltaleChannel[F],
+  param1Channel: Channel[F, String],
+  param2Channel: Channel[F, String],
+  param3Channel: Channel[F, String],
+  param4Channel: Channel[F, String],
+  param5Channel: Channel[F, String],
+  param6Channel: Channel[F, String]
+) {
+  def setParam1(v: A): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, A](tt, param1Channel)(v)
+
+  def setParam2(v: B): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, B](tt, param2Channel)(v)
+
+  def setParam3(v: C): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, C](tt, param3Channel)(v)
+
+  def setParam4(v: D): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, D](tt, param4Channel)(v)
+
+  def setParam5(v: E): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, E](tt, param5Channel)(v)
+
+  def setParam6(v: G): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, G](tt, param6Channel)(v)
+}
+
+case class Command7Channels[F[_]: Monad, A: Encoder[*, String], B: Encoder[*, String], C: Encoder[
+  *,
+  String
+], D: Encoder[*, String], E: Encoder[*, String], G: Encoder[*, String], H: Encoder[*, String]](
+  tt:            TelltaleChannel[F],
+  param1Channel: Channel[F, String],
+  param2Channel: Channel[F, String],
+  param3Channel: Channel[F, String],
+  param4Channel: Channel[F, String],
+  param5Channel: Channel[F, String],
+  param6Channel: Channel[F, String],
+  param7Channel: Channel[F, String]
+) {
+  def setParam1(v: A): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, A](tt, param1Channel)(v)
+
+  def setParam2(v: B): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, B](tt, param2Channel)(v)
+
+  def setParam3(v: C): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, C](tt, param3Channel)(v)
+
+  def setParam4(v: D): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, D](tt, param4Channel)(v)
+
+  def setParam5(v: E): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, E](tt, param5Channel)(v)
+
+  def setParam6(v: G): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, G](tt, param6Channel)(v)
+
+  def setParam7(v: H): VerifiedEpics[F, F, Unit] =
+    writeCadParam[F, H](tt, param7Channel)(v)
+}
+
+trait BaseCommand[F[_], +S] {
+  def mark: S
+}
+
+def readTop(tops: Map[String, String], key: NonEmptyString): NonEmptyString =
+  tops
+    .get(key.value)
+    .flatMap(NonEmptyString.from(_).toOption)
+    .getOrElse(NonEmptyString.unsafeFrom(s"${key.value}:"))

--- a/modules/server/src/test/scala/navigate/server/TestEpicsCommands.scala
+++ b/modules/server/src/test/scala/navigate/server/TestEpicsCommands.scala
@@ -6,7 +6,7 @@ package navigate.server
 import cats.data.State
 import cats.syntax.all.*
 import monocle.Lens
-import navigate.server.tcs.TcsEpicsSystem.BaseCommand
+import navigate.server.tcs.BaseCommand
 
 case class TestEpicsCommands[S, E](cmds: List[State[S, E]]) {
   def post(s0: S): (S, List[E])                      = cmds.sequence.run(s0).value

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -6,7 +6,6 @@ package navigate.server.tcs
 import cats.effect.IO
 import cats.effect.Ref
 import cats.syntax.all.*
-import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.ComaOption
 import lucuma.core.enums.GuideProbe
 import lucuma.core.enums.Instrument
@@ -24,6 +23,7 @@ import lucuma.core.model.ProbeGuide
 import lucuma.core.model.TelescopeGuideConfig
 import lucuma.core.util.Enumerated
 import lucuma.core.util.TimeSpan
+import lucuma.refined.*
 import monocle.syntax.all.*
 import mouse.boolean.given
 import munit.CatsEffectSuite
@@ -1061,9 +1061,9 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
     StateRefs(tcs, p1, p2, oi),
     new TcsBaseControllerEpics[IO](
       TestTcsEpicsSystem.build(tcs),
-      TestWfsEpicsSystem.build("PWFS1", NonEmptyString.unsafeFrom("p1:"), p1),
-      TestWfsEpicsSystem.build("PWFS2", NonEmptyString.unsafeFrom("p2:"), p2),
-      TestWfsEpicsSystem.build("OIWFS", NonEmptyString.unsafeFrom("oi:"), oi),
+      TestWfsEpicsSystem.build("PWFS1", "p1:".refined, p1),
+      TestWfsEpicsSystem.build("PWFS2", "p2:".refined, p2),
+      TestWfsEpicsSystem.build("OIWFS", "oi:".refined, oi),
       DefaultTimeout,
       st
     )

--- a/modules/server/src/test/scala/navigate/server/tcs/TestTcsEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestTcsEpicsSystem.scala
@@ -20,7 +20,6 @@ import navigate.server.epicsdata.BinaryOnOff
 import navigate.server.epicsdata.BinaryYesNo
 import navigate.server.tcs.TcsChannels.EnclosureChannels
 import navigate.server.tcs.TcsChannels.GuideConfigStatusChannels
-import navigate.server.tcs.TcsChannels.GuiderGainsChannels
 import navigate.server.tcs.TcsChannels.M1GuideConfigChannels
 import navigate.server.tcs.TcsChannels.M2GuideConfigChannels
 import navigate.server.tcs.TcsChannels.MountGuideChannels
@@ -202,38 +201,6 @@ object TestTcsEpicsSystem {
     )
   }
 
-  case class GuiderGainsState(
-    p1TipGain:   TestChannel.State[String],
-    p1TiltGain:  TestChannel.State[String],
-    p1FocusGain: TestChannel.State[String],
-    p1Reset:     TestChannel.State[BinaryYesNo],
-    p2TipGain:   TestChannel.State[String],
-    p2TiltGain:  TestChannel.State[String],
-    p2FocusGain: TestChannel.State[String],
-    p2Reset:     TestChannel.State[BinaryYesNo],
-    oiTipGain:   TestChannel.State[String],
-    oiTiltGain:  TestChannel.State[String],
-    oiFocusGain: TestChannel.State[String],
-    oiReset:     TestChannel.State[BinaryYesNo]
-  )
-
-  object GuiderGainsState {
-    val default: GuiderGainsState = GuiderGainsState(
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default,
-      TestChannel.State.default
-    )
-  }
-
   case class State(
     telltale:         TestChannel.State[String],
     telescopeParkDir: TestChannel.State[CadDirective],
@@ -261,7 +228,6 @@ object TestTcsEpicsSystem {
     m2GuideReset:     TestChannel.State[CadDirective],
     mountGuide:       MountGuideState,
     guideStatus:      GuideConfigState,
-    guiderGains:      GuiderGainsState,
     probeGuideMode:   ProbeGuideModeState,
     oiwfsSelect:      OiwfsSelectState
   )
@@ -365,7 +331,6 @@ object TestTcsEpicsSystem {
     m2GuideReset = TestChannel.State.default,
     mountGuide = MountGuideState.default,
     guideStatus = GuideConfigState.default,
-    guiderGains = GuiderGainsState.default,
     probeGuideMode = ProbeGuideModeState.default,
     oiwfsSelect = OiwfsSelectState.default
   )
@@ -700,24 +665,6 @@ object TestTcsEpicsSystem {
     )
   )
 
-  def buildGuiderGainsChannels[F[_]: Applicative](
-    s: Ref[F, State],
-    l: Lens[State, GuiderGainsState]
-  ): GuiderGainsChannels[F] = GuiderGainsChannels(
-    new TestChannel[F, State, String](s, l.andThen(Focus[GuiderGainsState](_.p1TipGain))),
-    new TestChannel[F, State, String](s, l.andThen(Focus[GuiderGainsState](_.p1TiltGain))),
-    new TestChannel[F, State, String](s, l.andThen(Focus[GuiderGainsState](_.p1FocusGain))),
-    new TestChannel[F, State, BinaryYesNo](s, l.andThen(Focus[GuiderGainsState](_.p1Reset))),
-    new TestChannel[F, State, String](s, l.andThen(Focus[GuiderGainsState](_.p2TipGain))),
-    new TestChannel[F, State, String](s, l.andThen(Focus[GuiderGainsState](_.p2TiltGain))),
-    new TestChannel[F, State, String](s, l.andThen(Focus[GuiderGainsState](_.p2FocusGain))),
-    new TestChannel[F, State, BinaryYesNo](s, l.andThen(Focus[GuiderGainsState](_.p2Reset))),
-    new TestChannel[F, State, String](s, l.andThen(Focus[GuiderGainsState](_.oiTipGain))),
-    new TestChannel[F, State, String](s, l.andThen(Focus[GuiderGainsState](_.oiTiltGain))),
-    new TestChannel[F, State, String](s, l.andThen(Focus[GuiderGainsState](_.oiFocusGain))),
-    new TestChannel[F, State, BinaryYesNo](s, l.andThen(Focus[GuiderGainsState](_.oiReset)))
-  )
-
   def buildGuideModeChannels[F[_]: Applicative](
     s: Ref[F, State],
     l: Lens[State, ProbeGuideModeState]
@@ -739,18 +686,6 @@ object TestTcsEpicsSystem {
     TcsChannels(
       telltale =
         TelltaleChannel[F]("dummy", new TestChannel[F, State, String](s, Focus[State](_.telltale))),
-      pwfs1Telltale =
-        TelltaleChannel[F]("dummy2",
-                           new TestChannel[F, State, String](s, Focus[State](_.telltale))
-        ),
-      pwfs2Telltale =
-        TelltaleChannel[F]("dummy3",
-                           new TestChannel[F, State, String](s, Focus[State](_.telltale))
-        ),
-      oiwfsTelltale =
-        TelltaleChannel[F]("dummy4",
-                           new TestChannel[F, State, String](s, Focus[State](_.telltale))
-        ),
       telescopeParkDir =
         new TestChannel[F, State, CadDirective](s, Focus[State](_.telescopeParkDir)),
       mountFollow = new TestChannel[F, State, String](s, Focus[State](_.mountFollow)),
@@ -777,7 +712,6 @@ object TestTcsEpicsSystem {
       mountGuide = buildMountGuideChannels(s, Focus[State](_.mountGuide)),
       oiwfs = buildWfsChannels(s, Focus[State](_.oiWfs)),
       guide = buildGuideStateChannels(s, Focus[State](_.guideStatus)),
-      guiderGains = buildGuiderGainsChannels(s, Focus[State](_.guiderGains)),
       probeGuideMode = buildGuideModeChannels(s, Focus[State](_.probeGuideMode)),
       oiwfsSelect = buildOiwfsSelectChannels(s, Focus[State](_.oiwfsSelect))
     )

--- a/modules/server/src/test/scala/navigate/server/tcs/TestWfsEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestWfsEpicsSystem.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.Applicative
+import cats.Monad
+import cats.Parallel
+import cats.effect.Ref
+import cats.effect.Temporal
+import eu.timepit.refined.types.string.NonEmptyString
+import monocle.Focus
+import navigate.epics.EpicsSystem
+import navigate.epics.EpicsSystem.TelltaleChannel
+import navigate.epics.TestChannel
+import navigate.server.acm.CadDirective
+import navigate.server.epicsdata.BinaryYesNo
+
+object TestWfsEpicsSystem {
+  case class State(
+    telltale:  TestChannel.State[String],
+    tipGain:   TestChannel.State[String],
+    tiltGain:  TestChannel.State[String],
+    focusGain: TestChannel.State[String],
+    reset:     TestChannel.State[BinaryYesNo],
+    gainsDir:  TestChannel.State[CadDirective],
+    resetDir:  TestChannel.State[CadDirective]
+  )
+
+  val defaultState: State = State(
+    TestChannel.State.default,
+    TestChannel.State.default,
+    TestChannel.State.default,
+    TestChannel.State.default,
+    TestChannel.State.default,
+    TestChannel.State.default,
+    TestChannel.State.default
+  )
+
+  def buildChannels[F[_]: Applicative](
+    sysName: String,
+    top:     NonEmptyString,
+    s:       Ref[F, State]
+  ): WfsChannels[F] = WfsChannels(
+    telltale =
+      TelltaleChannel[F]("sysName", new TestChannel[F, State, String](s, Focus[State](_.telltale))),
+    tipGain = new TestChannel[F, State, String](s, Focus[State](_.tipGain)),
+    tiltGain = new TestChannel[F, State, String](s, Focus[State](_.tiltGain)),
+    focusGain = new TestChannel[F, State, String](s, Focus[State](_.focusGain)),
+    reset = new TestChannel[F, State, BinaryYesNo](s, Focus[State](_.reset)),
+    gainsDir = new TestChannel[F, State, CadDirective](s, Focus[State](_.gainsDir)),
+    resetDir = new TestChannel[F, State, CadDirective](s, Focus[State](_.resetDir))
+  )
+
+  def build[F[_]: Monad: Temporal: Parallel](
+    sysName: String,
+    top:     NonEmptyString,
+    s:       Ref[F, State]
+  ): WfsEpicsSystem[F] = WfsEpicsSystem.buildSystem(buildChannels(sysName, top, s))
+
+}

--- a/modules/stateengine/src/main/scala/navigate/stateengine/Handler.scala
+++ b/modules/stateengine/src/main/scala/navigate/stateengine/Handler.scala
@@ -11,7 +11,7 @@ import fs2.Stream
 import navigate.stateengine.Handler.RetVal
 
 /**
- * Type constructor where all Observe side effect are managed. Handler is a State machine inside a
+ * Type constructor where all Navigate side effect are managed. Handler is a State machine inside a
  * F, which can produce Streams as output. It is combined with the input stream to run observe
  * engine.
  *
@@ -105,6 +105,9 @@ object Handler {
 
   def get[F[_], D, V]: Handler[F, D, V, D] =
     State.get[D].toHandle
+
+  def replace[F[_], D, V](d: D): Handler[F, D, V, Unit] =
+    State.set[D](d).toHandle
 
   def inspect[F[_], D, V, A](f: D => A): Handler[F, D, V, A] =
     State.inspect[D, A](f).toHandle


### PR DESCRIPTION
This PR adds the setup for the OIWFS signal processing.
The code switches between generating zernikes and activating the QL output stream automatically, depending on if the OIWFS is actively used for guiding or not.