### PR TITLE
Changed format to write coordinates in TCS.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
@@ -32,10 +32,10 @@ import navigate.server.epicsdata.BinaryYesNo
 import navigate.server.epicsdata.BinaryYesNo.given
 import navigate.server.tcs.TcsEpicsSystem.TcsStatus
 
-import scala.concurrent.duration.FiniteDuration
-import TcsChannels.{ProbeChannels, ProbeTrackingChannels, SlewChannels, TargetChannels, WfsChannels}
-
 import java.util.Locale
+import scala.concurrent.duration.FiniteDuration
+
+import TcsChannels.{ProbeChannels, ProbeTrackingChannels, SlewChannels, TargetChannels, WfsChannels}
 
 trait TcsEpicsSystem[F[_]] {
   // TcsCommands accumulates the list of channels that need to be written to set parameters.

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
@@ -33,8 +33,9 @@ import navigate.server.epicsdata.BinaryYesNo.given
 import navigate.server.tcs.TcsEpicsSystem.TcsStatus
 
 import scala.concurrent.duration.FiniteDuration
-
 import TcsChannels.{ProbeChannels, ProbeTrackingChannels, SlewChannels, TargetChannels, WfsChannels}
+
+import java.util.Locale
 
 trait TcsEpicsSystem[F[_]] {
   // TcsCommands accumulates the list of channels that need to be written to set parameters.
@@ -1059,6 +1060,17 @@ object TcsEpicsSystem {
     )
   }
 
+  def formatAngleCoord(d: Double): String = {
+    val absVal = scala.math.abs(d)
+    val sign   = scala.math.signum(d)
+
+    val deg = scala.math.floor(absVal)
+    val min = scala.math.floor((absVal - deg) * 60.0)
+    val sec = ((absVal - deg) * 60.0 - min) * 60.0
+
+    f"${(deg * sign).toInt}%d:${min.toInt}%02d:" + "%02f".formatLocal(Locale.US, sec)
+  }
+
   case class TargetCommandChannels[F[_]: Monad](
     tt:             TelltaleChannel[F],
     targetChannels: TargetChannels[F]
@@ -1068,9 +1080,9 @@ object TcsEpicsSystem {
     def coordSystem(v: String): VerifiedEpics[F, F, Unit]    =
       writeCadParam[F, String](tt, targetChannels.coordSystem)(v)
     def coord1(v: Double): VerifiedEpics[F, F, Unit]         =
-      writeCadParam[F, Double](tt, targetChannels.coord1)(v)
+      writeCadParam[F, String](tt, targetChannels.coord1)(formatAngleCoord(v))
     def coord2(v: Double): VerifiedEpics[F, F, Unit]         =
-      writeCadParam[F, Double](tt, targetChannels.coord2)(v)
+      writeCadParam[F, String](tt, targetChannels.coord2)(formatAngleCoord(v))
     def epoch(v: Double): VerifiedEpics[F, F, Unit]          =
       writeCadParam[F, Double](tt, targetChannels.epoch)(v)
     def equinox(v: String): VerifiedEpics[F, F, Unit]        =

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -12,10 +12,7 @@ import lucuma.core.enums.Instrument
 import lucuma.core.enums.M1Source
 import lucuma.core.enums.MountGuideOption
 import lucuma.core.enums.TipTiltSource
-import lucuma.core.math.Angle
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Epoch
-import lucuma.core.math.Wavelength
+import lucuma.core.math.{Angle, Coordinates, Epoch, HourAngle, Wavelength}
 import lucuma.core.model.M1GuideConfig
 import lucuma.core.model.M2GuideConfig
 import lucuma.core.model.M2GuideConfig.M2GuideOn
@@ -38,7 +35,6 @@ import navigate.server.epicsdata.BinaryYesNo
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
-
 import Target.SiderealTarget
 import TcsBaseController.*
 import TestTcsEpicsSystem.GuideConfigState
@@ -215,15 +211,13 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       assert(rs.sourceA.coordSystem.connected)
       assert(rs.sourceA.ephemerisFile.connected)
       assertEquals(rs.sourceA.objectName.value, target.objectName.some)
-      assert(
-        rs.sourceA.coord1.value.exists(x =>
-          compareDouble(x.toDouble, target.coordinates.ra.toHourAngle.toDoubleHours)
-        )
+      assertEquals(
+        rs.sourceA.coord1.value.flatMap(HourAngle.fromStringHMS.getOption),
+        Some(target.coordinates.ra.toHourAngle)
       )
-      assert(
-        rs.sourceA.coord2.value.exists(x =>
-          compareDouble(x.toDouble, target.coordinates.dec.toAngle.toDoubleDegrees)
-        )
+      assertEquals(
+        rs.sourceA.coord2.value.flatMap(Angle.fromStringSignedDMS.getOption),
+        Some(target.coordinates.dec.toAngle)
       )
       assert(rs.sourceA.properMotion1.value.exists(x => compareDouble(x.toDouble, 0.0)))
       assert(rs.sourceA.properMotion2.value.exists(x => compareDouble(x.toDouble, 0.0)))
@@ -247,15 +241,13 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       assert(rs.oiwfsTarget.coordSystem.connected)
       assert(rs.oiwfsTarget.ephemerisFile.connected)
       assertEquals(rs.oiwfsTarget.objectName.value, oiwfsTarget.objectName.some)
-      assert(
-        rs.oiwfsTarget.coord1.value.exists(x =>
-          compareDouble(x.toDouble, oiwfsTarget.coordinates.ra.toHourAngle.toDoubleHours)
-        )
+      assertEquals(
+        rs.oiwfsTarget.coord1.value.flatMap(HourAngle.fromStringHMS.getOption),
+        Some(oiwfsTarget.coordinates.ra.toHourAngle)
       )
-      assert(
-        rs.oiwfsTarget.coord2.value.exists(x =>
-          compareDouble(x.toDouble, oiwfsTarget.coordinates.dec.toAngle.toDoubleDegrees)
-        )
+      assertEquals(
+        rs.oiwfsTarget.coord2.value.flatMap(Angle.fromStringSignedDMS.getOption),
+        Some(oiwfsTarget.coordinates.dec.toAngle)
       )
       assert(rs.oiwfsTarget.properMotion1.value.exists(x => compareDouble(x.toDouble, 0.0)))
       assert(rs.oiwfsTarget.properMotion2.value.exists(x => compareDouble(x.toDouble, 0.0)))
@@ -501,15 +493,13 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       assert(rs.oiwfsTarget.coordSystem.connected)
       assert(rs.oiwfsTarget.ephemerisFile.connected)
       assertEquals(rs.oiwfsTarget.objectName.value, oiwfsTarget.objectName.some)
-      assert(
-        rs.oiwfsTarget.coord1.value.exists(x =>
-          compareDouble(x.toDouble, oiwfsTarget.coordinates.ra.toHourAngle.toDoubleHours)
-        )
+      assertEquals(
+        rs.oiwfsTarget.coord1.value.flatMap(HourAngle.fromStringHMS.getOption),
+        Some(oiwfsTarget.coordinates.ra.toHourAngle)
       )
-      assert(
-        rs.oiwfsTarget.coord2.value.exists(x =>
-          compareDouble(x.toDouble, oiwfsTarget.coordinates.dec.toAngle.toDoubleDegrees)
-        )
+      assertEquals(
+        rs.oiwfsTarget.coord2.value.flatMap(Angle.fromStringSignedDMS.getOption),
+        Some(oiwfsTarget.coordinates.dec.toAngle)
       )
       assert(rs.oiwfsTarget.properMotion1.value.exists(x => compareDouble(x.toDouble, 0.0)))
       assert(rs.oiwfsTarget.properMotion2.value.exists(x => compareDouble(x.toDouble, 0.0)))

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -12,7 +12,11 @@ import lucuma.core.enums.Instrument
 import lucuma.core.enums.M1Source
 import lucuma.core.enums.MountGuideOption
 import lucuma.core.enums.TipTiltSource
-import lucuma.core.math.{Angle, Coordinates, Epoch, HourAngle, Wavelength}
+import lucuma.core.math.Angle
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Epoch
+import lucuma.core.math.HourAngle
+import lucuma.core.math.Wavelength
 import lucuma.core.model.M1GuideConfig
 import lucuma.core.model.M2GuideConfig
 import lucuma.core.model.M2GuideConfig.M2GuideOn
@@ -35,6 +39,7 @@ import navigate.server.epicsdata.BinaryYesNo
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
+
 import Target.SiderealTarget
 import TcsBaseController.*
 import TestTcsEpicsSystem.GuideConfigState


### PR DESCRIPTION
TCC write coordinates in the format DD:MM:SS, while Navigate was writing them as doubles. It seemed to work, but just in case I modified Navigate to use the same format as TCC.