### PR TITLE
Fixed format of arcsec in target coordinates.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
@@ -1068,7 +1068,7 @@ object TcsEpicsSystem {
     val min = scala.math.floor((absVal - deg) * 60.0)
     val sec = ((absVal - deg) * 60.0 - min) * 60.0
 
-    f"${(deg * sign).toInt}%d:${min.toInt}%02d:" + "%02f".formatLocal(Locale.US, sec)
+    f"${(deg * sign).toInt}%d:${min.toInt}%02d:" + "%09.6f".formatLocal(Locale.US, sec)
   }
 
   case class TargetCommandChannels[F[_]: Monad](


### PR DESCRIPTION
Fixed the format to write arcseconds in a target coordinates. Now it is correctly put with 2 digits. Also, decimals are limited to 6, because that is the limit in class `Angle`.