### PR TITLE
Sc 3283 implement target swap

### DIFF
--- a/modules/model/src/main/scala/navigate/model/NavigateCommand.scala
+++ b/modules/model/src/main/scala/navigate/model/NavigateCommand.scala
@@ -55,6 +55,7 @@ object NavigateCommand {
   ) extends NavigateCommand
   case object TcsConfigure                extends NavigateCommand
   case object Slew                        extends NavigateCommand
+  case object SwapTarget                  extends NavigateCommand
   case object InstSpecifics               extends NavigateCommand
   case object OiwfsTarget                 extends NavigateCommand
   case object OiwfsProbeTracking          extends NavigateCommand
@@ -102,6 +103,7 @@ object NavigateCommand {
       case _: EcsVentGatesMove   => "Ecs Vent Gates Move"
       case TcsConfigure          => "TCS Configuration"
       case Slew                  => "Slew"
+      case SwapTarget            => "Swap Target"
       case InstSpecifics         => "Instrument Specifics"
       case OiwfsTarget           => "OIWFS"
       case OiwfsProbeTracking    => "OIWFS Probe Tracking"

--- a/modules/model/src/main/scala/navigate/model/NavigateState.scala
+++ b/modules/model/src/main/scala/navigate/model/NavigateState.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.model
+
+case class NavigateState(
+  onSwappedTarget: Boolean
+)
+
+object NavigateState {
+  val default: NavigateState = NavigateState(onSwappedTarget = false)
+}

--- a/modules/model/src/main/scala/navigate/model/enums/AcFilter.scala
+++ b/modules/model/src/main/scala/navigate/model/enums/AcFilter.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.model.enums
+
+import lucuma.core.util.Enumerated
+
+enum AcFilter(val tag: String) extends Product with Serializable derives Enumerated {
+  case Neutral extends AcFilter("Neutral")
+  case U_Red1  extends AcFilter("U_Red1")
+  case B_Blue  extends AcFilter("B_Blue")
+  case V_Green extends AcFilter("V_Green")
+  case R_Red2  extends AcFilter("R_Red2")
+  case I_Red3  extends AcFilter("I_Red3")
+}

--- a/modules/model/src/main/scala/navigate/model/enums/AoFoldPosition.scala
+++ b/modules/model/src/main/scala/navigate/model/enums/AoFoldPosition.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.model.enums
+
+import lucuma.core.util.Enumerated
+
+enum AoFoldPosition(val tag: String) extends Product with Serializable derives Enumerated {
+  case Out extends AoFoldPosition("OUT")
+  case In  extends AoFoldPosition("In")
+}

--- a/modules/model/src/main/scala/navigate/model/enums/HrwfsPickupPosition.scala
+++ b/modules/model/src/main/scala/navigate/model/enums/HrwfsPickupPosition.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.model.enums
+
+import lucuma.core.util.Enumerated
+
+enum HrwfsPickupPosition(val tag: String) extends Product with Serializable derives Enumerated {
+  case Out extends HrwfsPickupPosition("OUT")
+  case In  extends HrwfsPickupPosition("In")
+}

--- a/modules/model/src/main/scala/navigate/model/enums/LightSource.scala
+++ b/modules/model/src/main/scala/navigate/model/enums/LightSource.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.model.enums
+
+import cats.Eq
+import cats.derived.*
+
+enum LightSource extends Product with Serializable derives Eq {
+  case Sky extends LightSource
+
+  case AO extends LightSource
+
+  case GCAL extends LightSource
+}

--- a/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
+++ b/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
@@ -13,6 +13,7 @@ import cats.effect.kernel.Sync
 import cats.syntax.all.*
 import fs2.Pipe
 import fs2.Stream
+import fs2.concurrent.Topic
 import io.circe.syntax.*
 import lucuma.core.enums.MountGuideOption
 import lucuma.core.enums.Site
@@ -32,6 +33,7 @@ import navigate.model.NavigateEvent.CommandFailure
 import navigate.model.NavigateEvent.CommandPaused
 import navigate.model.NavigateEvent.CommandStart
 import navigate.model.NavigateEvent.CommandSuccess
+import navigate.model.NavigateState
 import navigate.model.config.ControlStrategy
 import navigate.model.config.NavigateEngineConfiguration
 import navigate.model.enums.DomeMode
@@ -98,6 +100,8 @@ trait NavigateEngine[F[_]] {
   def getGuideState: F[GuideState]
   def getGuidersQuality: F[GuidersQualityValues]
   def getTelescopeState: F[TelescopeState]
+  def getNavigateState: F[NavigateState]
+  def getNavigateStateStream: Stream[F, NavigateState]
 }
 
 object NavigateEngine {
@@ -128,10 +132,12 @@ object NavigateEngine {
   }
 
   private case class NavigateEngineImpl[F[_]: Concurrent: Temporal: Logger](
-    site:    Site,
-    systems: Systems[F],
-    conf:    NavigateEngineConfiguration,
-    engine:  StateEngine[F, State, NavigateEvent]
+    site:     Site,
+    systems:  Systems[F],
+    conf:     NavigateEngineConfiguration,
+    engine:   StateEngine[F, State, NavigateEvent],
+    stateRef: Ref[F, State],
+    topic:    Topic[F, NavigateState]
   ) extends NavigateEngine[F]
       with Http4sClientDsl[F] {
 
@@ -165,8 +171,13 @@ object NavigateEngine {
         .whenA(conf.systemControl.observe === ControlStrategy.FullControl)
     }
 
+    private def navigateState(s: State): NavigateState =
+      NavigateState(onSwappedTarget = s.onSwappedTarget)
+
     override def eventStream: Stream[F, NavigateEvent] =
-      engine.process(startState)
+      engine.process(startState).evalMap { case (s, o) =>
+        stateRef.set(s) *> topic.publish1(navigateState(s)).as(o)
+      }
 
     override def mcsPark: F[Unit] =
       simpleCommand(engine, McsPark, systems.tcsCommon.mcsPark, Focus[State](_.mcsParkInProgress))
@@ -284,7 +295,7 @@ object NavigateEngine {
         Handler.modify[F, State, ApplyCommandResult](_.focus(_.onSwappedTarget).replace(false)) *>
           Handler.fromStream(
             Stream.eval(
-              systems.tcsCommon.tcsConfig(config)
+              systems.tcsCommon.restoreTarget(config)
             )
           ),
         Focus[State](_.tcsConfigInProgress)
@@ -412,15 +423,28 @@ object NavigateEngine {
     override def getGuidersQuality: F[GuidersQualityValues] = systems.tcsCommon.getGuideQuality
 
     override def getTelescopeState: F[TelescopeState] = systems.tcsCommon.getTelescopeState
+
+    override def getNavigateState: F[NavigateState] =
+      stateRef.get.map(s => NavigateState(s.onSwappedTarget))
+
+    override def getNavigateStateStream: Stream[F, NavigateState] =
+      topic.subscribeUnbounded
+        .mapAccumulate[Option[NavigateState], Option[NavigateState]](none) { (acc, ss) =>
+          (ss.some, if (acc.contains(ss)) none else ss.some)
+        }
+        .map(_._2)
+        .flattenOption
   }
 
   def build[F[_]: Concurrent: Temporal: Logger](
     site:    Site,
     systems: Systems[F],
     conf:    NavigateEngineConfiguration
-  ): F[NavigateEngine[F]] = StateEngine
-    .build[F, State, NavigateEvent]
-    .map(NavigateEngineImpl[F](site, systems, conf, _))
+  ): F[NavigateEngine[F]] = for {
+    eng <- StateEngine.build[F, State, NavigateEvent]
+    ref <- Ref.of[F, State](startState)
+    top <- Topic[F, NavigateState]
+  } yield NavigateEngineImpl[F](site, systems, conf, eng, ref, top)
 
   case class WfsConfigState(
     period:          Option[TimeSpan],

--- a/modules/server/src/main/scala/navigate/server/Systems.scala
+++ b/modules/server/src/main/scala/navigate/server/Systems.scala
@@ -67,11 +67,13 @@ object Systems {
           scs  <- ScsEpicsSystem.build(epicsSrv, readTop(tops, "m2".refined))
           crcs <- CrcsEpicsSystem.build(epicsSrv, readTop(tops, "cr".refined))
           ags  <- AgsEpicsSystem.build(epicsSrv, readTop(tops, "ag".refined))
-          r    <- Resource.eval(
-                    TcsSouthControllerEpics.build(EpicsSystems(tcs, p1, p2, oi, mcs, scs, crcs, ags),
-                                                  conf.ioTimeout
-                    )
-                  )
+          hr   <- AcquisitionCameraEpicsSystem.build(epicsSrv, readTop(tops, "hrwfs".refined))
+          r    <-
+            Resource.eval(
+              TcsSouthControllerEpics.build(EpicsSystems(tcs, p1, p2, oi, mcs, scs, crcs, ags, hr),
+                                            conf.ioTimeout
+              )
+            )
         } yield r
       else
         Resource.eval(TcsSouthControllerSim.build)
@@ -93,11 +95,13 @@ object Systems {
           scs  <- ScsEpicsSystem.build(epicsSrv, readTop(tops, "m2".refined))
           crcs <- CrcsEpicsSystem.build(epicsSrv, readTop(tops, "cr".refined))
           ags  <- AgsEpicsSystem.build(epicsSrv, readTop(tops, "ag".refined))
-          r    <- Resource.eval(
-                    TcsNorthControllerEpics.build(EpicsSystems(tcs, p1, p2, oi, mcs, scs, crcs, ags),
-                                                  conf.ioTimeout
-                    )
-                  )
+          hr   <- AcquisitionCameraEpicsSystem.build(epicsSrv, readTop(tops, "hrwfs".refined))
+          r    <-
+            Resource.eval(
+              TcsNorthControllerEpics.build(EpicsSystems(tcs, p1, p2, oi, mcs, scs, crcs, ags, hr),
+                                            conf.ioTimeout
+              )
+            )
         } yield r
       else
         Resource.eval(TcsNorthControllerSim.build)

--- a/modules/server/src/main/scala/navigate/server/acm/Decoder.scala
+++ b/modules/server/src/main/scala/navigate/server/acm/Decoder.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.acm
+
+trait Decoder[B, A] {
+  def decode(b: B): A
+}
+
+object Decoder {
+  given [B]: Decoder[B, B] = (b: B) => b
+
+  extension [B](b: B) {
+    def decode[A](using d: Decoder[B, A]): A = d.decode(b)
+  }
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/AcquisitionCameraChannels.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/AcquisitionCameraChannels.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.effect.Resource
+import eu.timepit.refined.types.string.NonEmptyString
+import navigate.epics.Channel
+import navigate.epics.EpicsService
+import navigate.epics.EpicsSystem.TelltaleChannel
+import navigate.epics.given
+
+case class AcquisitionCameraChannels[F[_]](
+  telltale: TelltaleChannel[F],
+  filter:   Channel[F, String]
+)
+
+object AcquisitionCameraChannels {
+
+  val sysName: String = "AC/HR"
+
+  def build[F[_]](
+    service: EpicsService[F],
+    top:     NonEmptyString
+  ): Resource[F, AcquisitionCameraChannels[F]] = for {
+    tt <- service.getChannel[String](top, "health.VAL").map(TelltaleChannel(sysName, _))
+    fl <- service.getChannel[String](top, "clfilterName.VAL")
+  } yield AcquisitionCameraChannels(
+    tt,
+    fl
+  )
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/AcquisitionCameraEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/AcquisitionCameraEpicsSystem.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.Applicative
+import cats.effect.Resource
+import cats.syntax.all.*
+import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.core.math.Wavelength
+import navigate.epics.EpicsService
+import navigate.epics.VerifiedEpics.VerifiedEpics
+import navigate.epics.VerifiedEpics.readChannel
+import navigate.model.enums.AcFilter
+import navigate.server.acm.Decoder
+import navigate.server.tcs.AcquisitionCameraEpicsSystem.AcquisitionCameraStatus
+
+trait AcquisitionCameraEpicsSystem[F[_]] {
+  val status: AcquisitionCameraStatus[F]
+}
+
+object AcquisitionCameraEpicsSystem {
+
+  val acFilterDec: Decoder[String, AcFilter] = new Decoder[String, AcFilter] {
+    override def decode(b: String): AcFilter = b match {
+      case "neutral" => AcFilter.Neutral
+      case "U-red1"  => AcFilter.U_Red1
+      case "B-blue"  => AcFilter.B_Blue
+      case "V-green" => AcFilter.V_Green
+      case "R-red2"  => AcFilter.R_Red2
+      case "I-red3"  => AcFilter.I_Red3
+      case _         => AcFilter.Neutral
+    }
+  }
+
+  extension (flt: AcFilter) {
+    def toWavelength: Wavelength = {
+      val NanoToPico: Int = 1000
+      flt match
+        case AcFilter.Neutral => Wavelength.unsafeFromIntPicometers(500 * NanoToPico)
+        case AcFilter.U_Red1  => Wavelength.unsafeFromIntPicometers(375 * NanoToPico)
+        case AcFilter.B_Blue  => Wavelength.unsafeFromIntPicometers(425 * NanoToPico)
+        case AcFilter.V_Green => Wavelength.unsafeFromIntPicometers(530 * NanoToPico)
+        case AcFilter.R_Red2  => Wavelength.unsafeFromIntPicometers(640 * NanoToPico)
+        case AcFilter.I_Red3  => Wavelength.unsafeFromIntPicometers(760 * NanoToPico)
+    }
+  }
+
+  trait AcquisitionCameraStatus[F[_]] {
+    def filter: VerifiedEpics[F, F, AcFilter]
+  }
+
+  private[tcs] def buildSystem[F[_]: Applicative](
+    chs: AcquisitionCameraChannels[F]
+  ): AcquisitionCameraEpicsSystem[F] =
+    new AcquisitionCameraEpicsSystem[F] {
+      override val status: AcquisitionCameraStatus[F] = new AcquisitionCameraStatus[F] {
+        override def filter: VerifiedEpics[F, F, AcFilter] =
+          readChannel(chs.telltale, chs.filter).map(_.map(acFilterDec.decode))
+      }
+    }
+
+  def build[F[_]: Applicative](
+    service: EpicsService[F],
+    top:     NonEmptyString
+  ): Resource[F, AcquisitionCameraEpicsSystem[F]] =
+    AcquisitionCameraChannels.build(service, top).map(buildSystem)
+
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/AgsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/AgsEpicsSystem.scala
@@ -24,6 +24,7 @@ trait AgsEpicsSystem[F[_]] {
 }
 
 object AgsEpicsSystem {
+
   trait AgsStatus[F[_]] {
     def inPosition: VerifiedEpics[F, F, Boolean]
     def sfParked: VerifiedEpics[F, F, ParkStatus]
@@ -34,6 +35,14 @@ object AgsEpicsSystem {
     def p2Follow: VerifiedEpics[F, F, FollowStatus]
     def oiParked: VerifiedEpics[F, F, ParkStatus]
     def oiFollow: VerifiedEpics[F, F, FollowStatus]
+    def flamingos2Port: VerifiedEpics[F, F, Int]
+    def ghostPort: VerifiedEpics[F, F, Int]
+    def gmosPort: VerifiedEpics[F, F, Int]
+    def gnirsPort: VerifiedEpics[F, F, Int]
+    def gpiPort: VerifiedEpics[F, F, Int]
+    def gsaoiPort: VerifiedEpics[F, F, Int]
+    def nifsPort: VerifiedEpics[F, F, Int]
+    def niriPort: VerifiedEpics[F, F, Int]
   }
 
   private[tcs] def buildSystem[F[_]: Applicative](
@@ -88,6 +97,30 @@ object AgsEpicsSystem {
               case _    => NotFollowing
             }
           }
+
+        override def flamingos2Port: VerifiedEpics[F, F, Int] =
+          VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.f2)
+
+        override def ghostPort: VerifiedEpics[F, F, Int] =
+          VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.ghost)
+
+        override def gmosPort: VerifiedEpics[F, F, Int] =
+          VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.gmos)
+
+        override def gnirsPort: VerifiedEpics[F, F, Int] =
+          VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.gnirs)
+
+        override def gpiPort: VerifiedEpics[F, F, Int] =
+          VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.gpi)
+
+        override def gsaoiPort: VerifiedEpics[F, F, Int] =
+          VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.gsaoi)
+
+        override def nifsPort: VerifiedEpics[F, F, Int] =
+          VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.nifs)
+
+        override def niriPort: VerifiedEpics[F, F, Int] =
+          VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.niri)
       }
     }
 

--- a/modules/server/src/main/scala/navigate/server/tcs/EpicsSystems.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/EpicsSystems.scala
@@ -11,5 +11,6 @@ case class EpicsSystems[F[_]](
   mcs:      McsEpicsSystem[F],
   scs:      ScsEpicsSystem[F],
   crcs:     CrcsEpicsSystem[F],
-  ags:      AgsEpicsSystem[F]
+  ags:      AgsEpicsSystem[F],
+  hrwfs:    AcquisitionCameraEpicsSystem[F]
 )

--- a/modules/server/src/main/scala/navigate/server/tcs/InstrumentPorts.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/InstrumentPorts.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+case class InstrumentPorts(
+  flamingos2Port: Int,
+  ghostPort:      Int,
+  gmosPort:       Int,
+  gnirsPort:      Int,
+  gpiPort:        Int,
+  gsaoiPort:      Int,
+  nifsPort:       Int,
+  niriPort:       Int
+)

--- a/modules/server/src/main/scala/navigate/server/tcs/LightPath.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/LightPath.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import lucuma.core.enums.LightSinkName
+import navigate.model.enums.LightSource
+
+case class LightPath(
+  form: LightSource,
+  to:   LightSinkName
+)

--- a/modules/server/src/main/scala/navigate/server/tcs/ScienceFold.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/ScienceFold.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.*
+import cats.syntax.all.*
+import lucuma.core.enums.LightSinkName
+import navigate.model.enums.LightSource
+
+sealed trait ScienceFold extends Product with Serializable
+
+object ScienceFold {
+  case object Parked                                                             extends ScienceFold
+  final case class Position(source: LightSource, sink: LightSinkName, port: Int) extends ScienceFold
+
+  given Eq[Position] = Eq.by(x => (x.source, x.sink, x.port))
+
+  given Eq[ScienceFold] = Eq.instance {
+    case (Parked, Parked)           => true
+    case (a: Position, b: Position) => a === b
+    case _                          => false
+  }
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/ScienceFoldPositionCodex.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/ScienceFoldPositionCodex.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.parse.Parser
+import cats.parse.Parser0
+import cats.parse.Rfc5234.char
+import cats.syntax.all.*
+import lucuma.core.enums.LightSinkName
+import lucuma.core.enums.parser.EnumParsers
+import lucuma.core.parser.MiscParsers.int
+import navigate.model.enums.LightSource
+import navigate.model.enums.LightSource.*
+import navigate.server.acm.Decoder
+import navigate.server.acm.Encoder
+import navigate.server.tcs.ScienceFold.Parked
+import navigate.server.tcs.ScienceFold.Position
+
+// Decoding and encoding the science fold position require some common definitions, therefore I
+// put them inside an object
+private[server] trait ScienceFoldPositionCodex:
+
+  private val AO_PREFIX   = "ao2"
+  private val GCAL_PREFIX = "gcal2"
+  private val PARK_POS    = "park-pos"
+
+  val lightSink: Parser[LightSinkName] = EnumParsers.enumBy[LightSinkName](_.name)
+
+  def prefixed(p: String, s: LightSource): Parser0[ScienceFold] =
+    (Parser.string0(p) *> lightSink ~ int)
+      .map: (ls, port) =>
+        Position(s, ls, port)
+      .widen[ScienceFold]
+
+  val park: Parser[ScienceFold] =
+    (Parser.string(PARK_POS) <* char.rep.?).as(Parked)
+
+  given Decoder[String, Option[ScienceFold]] = (t: String) =>
+    (park | prefixed(AO_PREFIX, AO) | prefixed(GCAL_PREFIX, GCAL) | prefixed("", Sky))
+      .parseAll(t)
+      .toOption
+
+  given Encoder[Position, String] = (a: Position) =>
+    val instAGName = a.sink.name + a.port.toString
+
+    a.source match {
+      case Sky  => instAGName
+      case AO   => AO_PREFIX + instAGName
+      case GCAL => GCAL_PREFIX + instAGName
+    }
+
+  extension (a: Position) {
+    def encode: String = Encoder.encode(a)
+  }
+
+object ScienceFoldPositionCodex extends ScienceFoldPositionCodex

--- a/modules/server/src/main/scala/navigate/server/tcs/Target.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/Target.scala
@@ -10,6 +10,7 @@ import lucuma.core.math.Parallax
 import lucuma.core.math.ProperMotion
 import lucuma.core.math.RadialVelocity
 import lucuma.core.math.Wavelength
+import monocle.Lens
 
 sealed trait Target extends Product with Serializable {
   val objectName: String
@@ -44,5 +45,22 @@ object Target {
     override val wavelength: Option[Wavelength],
     ephemerisFile:           String
   ) extends Target
+
+  val objectName: Lens[Target, String] = Lens.apply[Target, String](_.objectName) { s =>
+    {
+      case a: SiderealTarget  => a.copy(objectName = s)
+      case a: AzElTarget      => a.copy(objectName = s)
+      case a: EphemerisTarget => a.copy(objectName = s)
+    }
+  }
+
+  val wavelength: Lens[Target, Option[Wavelength]] =
+    Lens.apply[Target, Option[Wavelength]](_.wavelength) { s =>
+      {
+        case a: SiderealTarget  => a.copy(wavelength = s)
+        case a: AzElTarget      => a.copy(wavelength = s)
+        case a: EphemerisTarget => a.copy(wavelength = s)
+      }
+    }
 
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseController.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseController.scala
@@ -4,12 +4,14 @@
 package navigate.server.tcs
 
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.LightSinkName
 import lucuma.core.math.Angle
 import lucuma.core.model.TelescopeGuideConfig
 import lucuma.core.util.TimeSpan
 import navigate.model.enums.CentralBafflePosition
 import navigate.model.enums.DeployableBafflePosition
 import navigate.model.enums.DomeMode
+import navigate.model.enums.LightSource
 import navigate.model.enums.ShutterMode
 import navigate.server.ApplyCommandResult
 
@@ -48,10 +50,12 @@ trait TcsBaseController[F[_]] {
     deployable: DeployableBafflePosition
   ): F[ApplyCommandResult]
   def scsFollow(enable:           Boolean): F[ApplyCommandResult]
+  def lightPath(from:             LightSource, to:        LightSinkName): F[ApplyCommandResult]
 
   def getGuideState: F[GuideState]
   def getGuideQuality: F[GuidersQualityValues]
   def getTelescopeState: F[TelescopeState]
+  def getInstrumentPorts: F[InstrumentPorts]
 }
 
 object TcsBaseController {

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseController.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseController.scala
@@ -33,7 +33,8 @@ trait TcsBaseController[F[_]] {
   def ecsVentGatesMove(gateEast:  Double, westGate:       Double): F[ApplyCommandResult]
   def tcsConfig(config:           TcsConfig): F[ApplyCommandResult]
   def slew(slewOptions:           SlewOptions, tcsConfig: TcsConfig): F[ApplyCommandResult]
-  def swapTarget(target:          Target): F[ApplyCommandResult]
+  def swapTarget(swapConfig:      SwapConfig): F[ApplyCommandResult]
+  def restoreTarget(config:       TcsConfig): F[ApplyCommandResult]
   def instrumentSpecifics(config: InstrumentSpecifics): F[ApplyCommandResult]
   def oiwfsTarget(target:         Target): F[ApplyCommandResult]
   def rotIaa(angle:               Angle): F[ApplyCommandResult]
@@ -67,6 +68,20 @@ object TcsBaseController {
     rotatorTrackConfig:  RotatorTrackConfig,
     instrument:          Instrument
   )
+
+  case class SwapConfig(
+    guideTarget:        Target,
+    acSpecifics:        InstrumentSpecifics,
+    rotatorTrackConfig: RotatorTrackConfig
+  ) {
+    lazy val toTcsConfig: TcsConfig = TcsConfig(
+      guideTarget,
+      acSpecifics,
+      None,
+      rotatorTrackConfig,
+      Instrument.AcqCam
+    )
+  }
 
   val SystemDefault: String  = "FK5"
   val EquinoxDefault: String = "J2000"

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseController.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseController.scala
@@ -31,6 +31,7 @@ trait TcsBaseController[F[_]] {
   def ecsVentGatesMove(gateEast:  Double, westGate:       Double): F[ApplyCommandResult]
   def tcsConfig(config:           TcsConfig): F[ApplyCommandResult]
   def slew(slewOptions:           SlewOptions, tcsConfig: TcsConfig): F[ApplyCommandResult]
+  def swapTarget(target:          Target): F[ApplyCommandResult]
   def instrumentSpecifics(config: InstrumentSpecifics): F[ApplyCommandResult]
   def oiwfsTarget(target:         Target): F[ApplyCommandResult]
   def rotIaa(angle:               Angle): F[ApplyCommandResult]

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
@@ -6,6 +6,7 @@ package navigate.server.tcs
 import cats.effect.Ref
 import cats.effect.Sync
 import cats.syntax.all.*
+import lucuma.core.enums.LightSinkName
 import lucuma.core.enums.MountGuideOption
 import lucuma.core.math.Angle
 import lucuma.core.model.M1GuideConfig
@@ -17,6 +18,7 @@ import mouse.boolean.*
 import navigate.model.enums.CentralBafflePosition
 import navigate.model.enums.DeployableBafflePosition
 import navigate.model.enums.DomeMode
+import navigate.model.enums.LightSource
 import navigate.model.enums.ShutterMode
 import navigate.server.ApplyCommandResult
 import navigate.server.tcs.FollowStatus.*
@@ -161,5 +163,20 @@ class TcsBaseControllerSim[F[_]: Sync](
     .as(ApplyCommandResult.Completed)
 
   override def swapTarget(target: Target): F[ApplyCommandResult] =
+    ApplyCommandResult.Completed.pure[F]
+
+  override def getInstrumentPorts: F[InstrumentPorts] =
+    InstrumentPorts(
+      flamingos2Port = 1,
+      ghostPort = 0,
+      gmosPort = 3,
+      gnirsPort = 0,
+      gpiPort = 0,
+      gsaoiPort = 5,
+      nifsPort = 0,
+      niriPort = 0
+    ).pure[F]
+
+  override def lightPath(from: LightSource, to: LightSinkName): F[ApplyCommandResult] =
     ApplyCommandResult.Completed.pure[F]
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
@@ -24,6 +24,7 @@ import navigate.server.ApplyCommandResult
 import navigate.server.tcs.FollowStatus.*
 import navigate.server.tcs.GuidersQualityValues.GuiderQuality
 import navigate.server.tcs.ParkStatus.*
+import navigate.server.tcs.TcsBaseController.SwapConfig
 
 class TcsBaseControllerSim[F[_]: Sync](
   guideRef:    Ref[F, GuideState],
@@ -162,7 +163,7 @@ class TcsBaseControllerSim[F[_]: Sync](
     )
     .as(ApplyCommandResult.Completed)
 
-  override def swapTarget(target: Target): F[ApplyCommandResult] =
+  override def swapTarget(swapConfig: SwapConfig): F[ApplyCommandResult] =
     ApplyCommandResult.Completed.pure[F]
 
   override def getInstrumentPorts: F[InstrumentPorts] =
@@ -178,5 +179,8 @@ class TcsBaseControllerSim[F[_]: Sync](
     ).pure[F]
 
   override def lightPath(from: LightSource, to: LightSinkName): F[ApplyCommandResult] =
+    ApplyCommandResult.Completed.pure[F]
+
+  override def restoreTarget(config: TcsBaseController.TcsConfig): F[ApplyCommandResult] =
     ApplyCommandResult.Completed.pure[F]
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
@@ -159,4 +159,7 @@ class TcsBaseControllerSim[F[_]: Sync](
       _.focus(_.scs).replace(MechSystemState(NotParked, enable.fold(Following, NotFollowing)))
     )
     .as(ApplyCommandResult.Completed)
+
+  override def swapTarget(target: Target): F[ApplyCommandResult] =
+    ApplyCommandResult.Completed.pure[F]
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/TrackingConfig.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TrackingConfig.scala
@@ -9,3 +9,8 @@ case class TrackingConfig(
   nodBchopA: Boolean,
   nodBchopB: Boolean
 )
+
+object TrackingConfig {
+  val default: TrackingConfig    = TrackingConfig(true, false, false, true)
+  val noTracking: TrackingConfig = TrackingConfig(false, false, false, false)
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/package.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/package.scala
@@ -6,6 +6,8 @@ package navigate.server.tcs
 import cats.Applicative
 import cats.Monad
 import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.core.enums.Instrument
+import lucuma.core.enums.LightSinkName
 import lucuma.core.util.NewType
 import navigate.epics.Channel
 import navigate.epics.EpicsSystem.TelltaleChannel
@@ -198,3 +200,23 @@ def readTop(tops: Map[String, String], key: NonEmptyString): NonEmptyString =
     .get(key.value)
     .flatMap(NonEmptyString.from(_).toOption)
     .getOrElse(NonEmptyString.unsafeFrom(s"${key.value}:"))
+
+extension (i: Instrument) {
+  def toLightSink: LightSinkName = i match
+    case Instrument.AcqCam     => LightSinkName.Ac
+    case Instrument.Flamingos2 => LightSinkName.F2
+    case Instrument.Ghost      => LightSinkName.Ghost
+    case Instrument.GmosNorth  => LightSinkName.Gmos
+    case Instrument.GmosSouth  => LightSinkName.Gmos
+    case Instrument.Gnirs      => LightSinkName.Gnirs
+    case Instrument.Gpi        => LightSinkName.Gpi
+    case Instrument.Gsaoi      => LightSinkName.Gsaoi
+    case Instrument.Igrins2    => LightSinkName.Igrins2
+    case Instrument.Nifs       => LightSinkName.Nifs
+    case Instrument.Niri       => LightSinkName.Niri_f6 // TODO: handle the other cases
+    case Instrument.Phoenix    => LightSinkName.Phoenix
+    case Instrument.Visitor    => LightSinkName.Visitor
+    case Instrument.Alopeke    => LightSinkName.Visitor
+    case Instrument.Zorro      => LightSinkName.Visitor
+    case _                     => LightSinkName.Ac
+}

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -1169,6 +1169,9 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
     crcs <- Ref.of[IO, TestCrcsEpicsSystem.State](TestCrcsEpicsSystem.defaultState)
     ags  <- Ref.of[IO, TestAgsEpicsSystem.State](TestAgsEpicsSystem.defaultState)
     st   <- Ref.of[IO, TcsBaseControllerEpics.State](TcsBaseControllerEpics.State.default)
+    ac   <- Ref.of[IO, TestAcquisitionCameraEpicsSystem.State](
+              TestAcquisitionCameraEpicsSystem.defaultState
+            )
   } yield (
     StateRefs(tcs, p1, p2, oi, mcs, scs, crcs, ags),
     new TcsBaseControllerEpics[IO](
@@ -1180,7 +1183,8 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
         TestMcsEpicsSystem.build(mcs),
         TestScsEpicsSystem.build(scs),
         TestCrcsEpicsSystem.build(crcs),
-        TestAgsEpicsSystem.build(ags)
+        TestAgsEpicsSystem.build(ags),
+        TestAcquisitionCameraEpicsSystem.build(ac)
       ),
       DefaultTimeout,
       st

--- a/modules/server/src/test/scala/navigate/server/tcs/TestAcquisitionCameraEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestAcquisitionCameraEpicsSystem.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.Applicative
+import cats.Monad
+import cats.Parallel
+import cats.effect.Ref
+import cats.effect.Temporal
+import monocle.Focus
+import navigate.epics.EpicsSystem.TelltaleChannel
+import navigate.epics.TestChannel
+
+object TestAcquisitionCameraEpicsSystem {
+  case class State(
+    telltale: TestChannel.State[String],
+    filter:   TestChannel.State[String]
+  )
+
+  val defaultState: State = State(
+    TestChannel.State.of(""),
+    TestChannel.State.of("")
+  )
+
+  def buildChannels[F[_]: Applicative](
+    s: Ref[F, State]
+  ): AcquisitionCameraChannels[F] = new AcquisitionCameraChannels[F](
+    telltale =
+      TelltaleChannel[F]("AC/HR", new TestChannel[F, State, String](s, Focus[State](_.telltale))),
+    filter = new TestChannel[F, State, String](s, Focus[State](_.filter))
+  )
+
+  def build[F[_]: Monad: Temporal: Parallel](
+    s: Ref[F, State]
+  ): AcquisitionCameraEpicsSystem[F] = AcquisitionCameraEpicsSystem.buildSystem(buildChannels(s))
+
+}

--- a/modules/server/src/test/scala/navigate/server/tcs/TestAgsEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestAgsEpicsSystem.scala
@@ -11,6 +11,7 @@ import cats.effect.Temporal
 import monocle.Focus
 import navigate.epics.EpicsSystem.TelltaleChannel
 import navigate.epics.TestChannel
+import navigate.server.tcs.AgsChannels.InstrumentPortChannels
 
 object TestAgsEpicsSystem {
 
@@ -24,7 +25,15 @@ object TestAgsEpicsSystem {
     p2Parked:   TestChannel.State[Int],
     p2Follow:   TestChannel.State[String],
     oiParked:   TestChannel.State[Int],
-    oiFollow:   TestChannel.State[String]
+    oiFollow:   TestChannel.State[String],
+    f2Port:     TestChannel.State[Int],
+    ghostPort:  TestChannel.State[Int],
+    gmosPort:   TestChannel.State[Int],
+    gnirsPort:  TestChannel.State[Int],
+    gpiPort:    TestChannel.State[Int],
+    gsaoiPort:  TestChannel.State[Int],
+    nifsPort:   TestChannel.State[Int],
+    niriPort:   TestChannel.State[Int]
   )
 
   val defaultState: State = State(
@@ -37,7 +46,15 @@ object TestAgsEpicsSystem {
     TestChannel.State.of(1),
     TestChannel.State.of(""),
     TestChannel.State.of(1),
-    TestChannel.State.of("")
+    TestChannel.State.of(""),
+    TestChannel.State.of(1),
+    TestChannel.State.of(3),
+    TestChannel.State.of(0),
+    TestChannel.State.of(0),
+    TestChannel.State.of(5),
+    TestChannel.State.of(0),
+    TestChannel.State.of(0),
+    TestChannel.State.of(0)
   )
 
   def buildChannels[F[_]: Applicative](
@@ -53,7 +70,17 @@ object TestAgsEpicsSystem {
     p2Parked = new TestChannel[F, State, Int](s, Focus[State](_.p2Parked)),
     p2Follow = new TestChannel[F, State, String](s, Focus[State](_.p2Follow)),
     oiParked = new TestChannel[F, State, Int](s, Focus[State](_.oiParked)),
-    oiFollow = new TestChannel[F, State, String](s, Focus[State](_.oiFollow))
+    oiFollow = new TestChannel[F, State, String](s, Focus[State](_.oiFollow)),
+    instrumentPorts = InstrumentPortChannels[F](
+      gmos = new TestChannel[F, State, Int](s, Focus[State](_.gmosPort)),
+      gsaoi = new TestChannel[F, State, Int](s, Focus[State](_.gsaoiPort)),
+      gpi = new TestChannel[F, State, Int](s, Focus[State](_.gpiPort)),
+      f2 = new TestChannel[F, State, Int](s, Focus[State](_.f2Port)),
+      niri = new TestChannel[F, State, Int](s, Focus[State](_.niriPort)),
+      gnirs = new TestChannel[F, State, Int](s, Focus[State](_.gnirsPort)),
+      nifs = new TestChannel[F, State, Int](s, Focus[State](_.nifsPort)),
+      ghost = new TestChannel[F, State, Int](s, Focus[State](_.ghostPort))
+    )
   )
 
   def build[F[_]: Monad: Temporal: Parallel](

--- a/modules/web/server/src/main/resources/NewTCC.graphql
+++ b/modules/web/server/src/main/resources/NewTCC.graphql
@@ -102,6 +102,12 @@ input TcsConfigInput {
     instrument: Instrument!
 }
 
+input SwapConfigInput {
+    guideTarget: TargetPropertiesInput!
+    acParams: InstrumentSpecificsInput!
+    rotator: RotatorTrackingInput!
+}
+
 enum RotatorTrackingMode {
     TRACKING
     FIXED
@@ -227,6 +233,8 @@ type Mutation {
     scsFollow(enable: Boolean!): OperationOutcome!
     slew(slewOptions: SlewOptionsInput!, config: TcsConfigInput!): OperationOutcome!
     tcsConfig(config: TcsConfigInput!): OperationOutcome!
+    swapTarget(swapConfig: SwapConfigInput!): OperationOutcome!
+    restoreTarget(config: TcsConfigInput!): OperationOutcome!
     instrumentSpecifics(instrumentSpecificsParams: InstrumentSpecificsInput!): OperationOutcome!
     rotatorConfig(config: RotatorTrackingInput!): OperationOutcome!
     oiwfsTarget(target: TargetPropertiesInput!): OperationOutcome!
@@ -237,7 +245,6 @@ type Mutation {
     oiwfsStopObserve: OperationOutcome!
     guideEnable(config: GuideConfigurationInput!): OperationOutcome!
     guideDisable: OperationOutcome!
-    swapTarget(guideTarget: TargetPropertiesInput!): OperationOutcome!
 }
 
 type Subscription {

--- a/modules/web/server/src/main/resources/NewTCC.graphql
+++ b/modules/web/server/src/main/resources/NewTCC.graphql
@@ -89,6 +89,10 @@ type TelescopeState {
     oiwfs: MechSystemState!
 }
 
+type NavigateState {
+    onSwappedTarget: Boolean!
+}
+
 input GuiderConfig{
     target: GuideTargetPropertiesInput!
     tracking: ProbeTrackingInput!
@@ -223,6 +227,7 @@ type GuidersQualityValues {
 type Query {
     telescopeState: TelescopeState!
     guideState: GuideConfigurationState!
+    navigateState: NavigateState!
 }
 
 type Mutation {
@@ -252,4 +257,5 @@ type Subscription {
     guideState: GuideConfigurationState!
     guidersQualityValues: GuidersQualityValues!
     telescopeState: TelescopeState!
+    navigateState: NavigateState!
 }

--- a/modules/web/server/src/main/resources/NewTCC.graphql
+++ b/modules/web/server/src/main/resources/NewTCC.graphql
@@ -237,6 +237,7 @@ type Mutation {
     oiwfsStopObserve: OperationOutcome!
     guideEnable(config: GuideConfigurationInput!): OperationOutcome!
     guideDisable: OperationOutcome!
+    swapTarget(guideTarget: TargetPropertiesInput!): OperationOutcome!
 }
 
 type Subscription {

--- a/modules/web/server/src/main/scala/navigate/web/server/http4s/NavigateMappings.scala
+++ b/modules/web/server/src/main/scala/navigate/web/server/http4s/NavigateMappings.scala
@@ -231,7 +231,26 @@ class NavigateMappings[F[_]: Sync](
       }
       .getOrElse(
         Result
-          .failure[OperationOutcome]("oiwfsProbeTracking parameters could not be parsed.")
+          .failure[OperationOutcome]("tcsConfig parameters could not be parsed.")
+          .pure[F]
+      )
+
+  def swapTarget(p: Path, env: Env): F[Result[OperationOutcome]] =
+    env
+      .get[Target]("guideTarget")(using classTag[Target])
+      .map { t =>
+        server
+          .swapTarget(t)
+          .attempt
+          .map(x =>
+            Result.success(
+              x.fold(e => OperationOutcome.failure(e.getMessage), _ => OperationOutcome.success)
+            )
+          )
+      }
+      .getOrElse(
+        Result
+          .failure[OperationOutcome]("swapTarget parameters could not be parsed.")
           .pure[F]
       )
 

--- a/modules/web/server/src/main/scala/navigate/web/server/http4s/encoder/package.scala
+++ b/modules/web/server/src/main/scala/navigate/web/server/http4s/encoder/package.scala
@@ -10,6 +10,7 @@ import io.circe.syntax.*
 import lucuma.core.model.M1GuideConfig
 import lucuma.core.model.M2GuideConfig
 import lucuma.core.util.Timestamp
+import navigate.model.NavigateState
 import navigate.server.tcs.GuideState
 import navigate.server.tcs.GuidersQualityValues
 import navigate.server.tcs.MechSystemState
@@ -76,6 +77,11 @@ package object encoder {
       "pwfs1" -> s.pwfs1.asJson,
       "pwfs2" -> s.pwfs2.asJson,
       "oiwfs" -> s.oiwfs.asJson
+    )
+
+  given Encoder[NavigateState] = s =>
+    Json.obj(
+      "onSwappedTarget" -> s.onSwappedTarget.asJson
     )
 
 }

--- a/modules/web/server/src/test/scala/navigate/web/server/http4s/NavigateMappingsSuite.scala
+++ b/modules/web/server/src/test/scala/navigate/web/server/http4s/NavigateMappingsSuite.scala
@@ -995,6 +995,8 @@ object NavigateMappingsTest {
       override def getTelescopeState: IO[TelescopeState] = p.get
 
       override def scsFollow(enable: Boolean): IO[Unit] = IO.unit
+
+      override def swapTarget(target: Target): IO[Unit] = IO.unit
     }
   }
 


### PR DESCRIPTION
Implemented methods to point the telescope to a guide target and sending the light to the acquisition camera (swapTarget) and  to restore the telescope to the science target. Those are now in the API.
As a side development, now all the code to set the light path is there, just need to implement the GraphQL API part.