### PR TITLE
Fixed OIWFS readout control.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
+++ b/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
@@ -401,13 +401,11 @@ object NavigateEngine {
       OiwfsObserve,
       transformCommand(
         OiwfsObserve,
-        Handler.get[F, State, ApplyCommandResult].flatMap { st =>
-          Handler.fromStream(
-            Stream.eval(
-              systems.tcsCommon.oiwfsObserve(period)
-            )
+        Handler.fromStream(
+          Stream.eval(
+            systems.tcsCommon.oiwfsObserve(period)
           )
-        },
+        ),
         Focus[State](_.oiwfsObserve)
       ),
       Focus[State](_.oiwfsObserve)
@@ -425,13 +423,11 @@ object NavigateEngine {
       AcObserve,
       transformCommand(
         AcObserve,
-        Handler.get[F, State, ApplyCommandResult].flatMap { st =>
-          Handler.fromStream(
-            Stream.eval(
-              systems.tcsCommon.hrwfsObserve(period)
-            )
+        Handler.fromStream(
+          Stream.eval(
+            systems.tcsCommon.hrwfsObserve(period)
           )
-        },
+        ),
         Focus[State](_.acObserve)
       ),
       Focus[State](_.acObserve)

--- a/modules/server/src/main/scala/navigate/server/Systems.scala
+++ b/modules/server/src/main/scala/navigate/server/Systems.scala
@@ -57,14 +57,11 @@ object Systems {
                     "dc:fgDiag1P2.VALQ".refined,
                     "dc:fgDiag1P2.VALB".refined
                   )
-          oi   <- WfsEpicsSystem.build(
+          oi   <- OiwfsEpicsSystem.build(
                     epicsSrv,
-                    "OIWFS",
                     readTop(tops, "oiwfs".refined),
-                    "dc:initSigInitFgGain.PROC".refined,
                     "dc:fgDiag1P2.VALQ".refined,
-                    "dc:fgDiag1P2.VALB".refined,
-                    "dc:seeing.VAL".refined
+                    "dc:fgDiag1P2.VALB".refined
                   )
           mcs  <- McsEpicsSystem.build(epicsSrv, readTop(tops, "mc".refined))
           scs  <- ScsEpicsSystem.build(epicsSrv, readTop(tops, "m2".refined))
@@ -87,14 +84,11 @@ object Systems {
           tcs  <- TcsEpicsSystem.build(epicsSrv, tops)
           p1   <- WfsEpicsSystem.build(epicsSrv, "PWFS1", readTop(tops, "pwfs1".refined))
           p2   <- WfsEpicsSystem.build(epicsSrv, "PWFS2", readTop(tops, "pwfs2".refined))
-          oi   <- WfsEpicsSystem.build(
+          oi   <- OiwfsEpicsSystem.build(
                     epicsSrv,
-                    "OIWFS",
                     readTop(tops, "oiwfs".refined),
-                    "dc:initSigInitFgGain.PROC".refined,
                     "dc:fgDiag1Oi.VALQ".refined,
-                    "dc:fgDiag1Oi.VALB".refined,
-                    "dc:seeing.VAL".refined
+                    "dc:fgDiag1Oi.VALB".refined
                   )
           mcs  <- McsEpicsSystem.build(epicsSrv, readTop(tops, "mc".refined))
           scs  <- ScsEpicsSystem.build(epicsSrv, readTop(tops, "m2".refined))

--- a/modules/server/src/main/scala/navigate/server/tcs/EpicsSystems.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/EpicsSystems.scala
@@ -7,7 +7,7 @@ case class EpicsSystems[F[_]](
   tcsEpics: TcsEpicsSystem[F],
   pwfs1:    WfsEpicsSystem[F],
   pwfs2:    WfsEpicsSystem[F],
-  oiwfs:    WfsEpicsSystem[F],
+  oiwfs:    OiwfsEpicsSystem[F],
   mcs:      McsEpicsSystem[F],
   scs:      ScsEpicsSystem[F],
   crcs:     CrcsEpicsSystem[F],

--- a/modules/server/src/main/scala/navigate/server/tcs/OiwfsChannels.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/OiwfsChannels.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.effect.Resource
+import eu.timepit.refined.types.string.NonEmptyString
+import navigate.epics.Channel
+import navigate.epics.EpicsService
+import navigate.epics.given
+import navigate.server.acm.CadDirective
+
+case class OiwfsChannels[F[_]](
+  detSigModeSeqDarkDir: Channel[F, CadDirective],
+  seqDarkFilename:      Channel[F, String],
+  detSigModeSeqDir:     Channel[F, CadDirective],
+  z2m2:                 Channel[F, String],
+  detSigInitDir:        Channel[F, CadDirective],
+  darkFilename:         Channel[F, String]
+)
+
+object OiwfsChannels {
+  def build[F[_]](
+    service: EpicsService[F],
+    top:     NonEmptyString
+  ): Resource[F, OiwfsChannels[F]] = for {
+    dd   <- service.getChannel[CadDirective](top, "dc:detSigModeSeqDark.DIR")
+    sfn  <- service.getChannel[String](top, "dc:detSigModeSeqDark.C")
+    smd  <- service.getChannel[CadDirective](top, "dc:detSigModeSeq.DIR")
+    z2m2 <- service.getChannel[String](top, "dc:detSigModeSeq.P")
+    id   <- service.getChannel[CadDirective](top, "dc:detSigInit.DIR")
+    fn   <- service.getChannel[String](top, "dc:detSigInit.B")
+  } yield OiwfsChannels(
+    detSigModeSeqDarkDir = dd,
+    seqDarkFilename = sfn,
+    detSigModeSeqDir = smd,
+    z2m2 = z2m2,
+    detSigInitDir = id,
+    darkFilename = fn
+  )
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/OiwfsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/OiwfsEpicsSystem.scala
@@ -1,0 +1,148 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.Monad
+import cats.Parallel
+import cats.effect.Resource
+import cats.effect.Temporal
+import cats.effect.std.Dispatcher
+import cats.syntax.all.*
+import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.refined.*
+import navigate.epics.EpicsService
+import navigate.epics.EpicsSystem.TelltaleChannel
+import navigate.epics.VerifiedEpics
+import navigate.epics.VerifiedEpics.*
+import navigate.server.ApplyCommandResult
+import navigate.server.acm.*
+import navigate.server.acm.ParameterList.*
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+
+trait OiwfsEpicsSystem[F[_]] extends WfsEpicsSystem[F] {
+  def startDarkCommand(timeout:       FiniteDuration): OiwfsEpicsSystem.DarkCommand[F]
+  def startClosedLoopCommand(timeout: FiniteDuration): OiwfsEpicsSystem.ClosedLoopCommand[F]
+  def startSignalProcCommand(timeout: FiniteDuration): OiwfsEpicsSystem.SignalProcCommand[F]
+}
+
+object OiwfsEpicsSystem {
+
+  trait DarkCommand[F[_]] {
+    def post: VerifiedEpics[F, F, ApplyCommandResult]
+    def filename(name: String): DarkCommand[F]
+  }
+
+  trait ClosedLoopCommand[F[_]] {
+    def post: VerifiedEpics[F, F, ApplyCommandResult]
+    def zernikes2m2(enable: Int): ClosedLoopCommand[F]
+  }
+
+  trait SignalProcCommand[F[_]] {
+    def post: VerifiedEpics[F, F, ApplyCommandResult]
+    def filename(name: String): SignalProcCommand[F]
+  }
+
+  val commandWaitTime: FiniteDuration = FiniteDuration(500, TimeUnit.MILLISECONDS)
+
+  private class DarkCommandImpl[F[_]: Monad: Temporal: Parallel](
+    telltale: TelltaleChannel[F],
+    channels: OiwfsChannels[F],
+    timeout:  FiniteDuration,
+    params:   ParameterList[F] = List.empty[VerifiedEpics[F, F, Unit]]
+  ) extends DarkCommand[F] {
+    private def addParam(p: VerifiedEpics[F, F, Unit]): DarkCommand[F] =
+      DarkCommandImpl(telltale, channels, timeout, params :+ p)
+
+    override def post: VerifiedEpics[F, F, ApplyCommandResult] =
+      params.compile *> writeChannel(telltale, channels.detSigModeSeqDarkDir)(
+        CadDirective.START.pure[F]
+      ) *>
+        VerifiedEpics.liftF(Temporal[F].sleep(commandWaitTime).as(ApplyCommandResult.Completed))
+
+    override def filename(name: String): DarkCommand[F] = addParam(
+      writeCadParam(telltale, channels.seqDarkFilename)(name)
+    )
+  }
+
+  private class ClosedLoopCommandImpl[F[_]: Monad: Temporal: Parallel](
+    telltale: TelltaleChannel[F],
+    channels: OiwfsChannels[F],
+    timeout:  FiniteDuration,
+    params:   ParameterList[F] = List.empty[VerifiedEpics[F, F, Unit]]
+  ) extends ClosedLoopCommand[F] {
+    private def addParam(p: VerifiedEpics[F, F, Unit]): ClosedLoopCommand[F] =
+      ClosedLoopCommandImpl(telltale, channels, timeout, params :+ p)
+
+    override def post: VerifiedEpics[F, F, ApplyCommandResult] =
+      params.compile *> writeChannel(telltale, channels.detSigModeSeqDir)(
+        CadDirective.START.pure[F]
+      ) *>
+        VerifiedEpics.liftF(Temporal[F].sleep(commandWaitTime).as(ApplyCommandResult.Completed))
+
+    override def zernikes2m2(enable: Int): ClosedLoopCommand[F] = addParam(
+      writeCadParam(telltale, channels.z2m2)(enable)
+    )
+  }
+
+  private class SignalProcCommandImpl[F[_]: Monad: Temporal: Parallel](
+    telltale: TelltaleChannel[F],
+    channels: OiwfsChannels[F],
+    timeout:  FiniteDuration,
+    params:   ParameterList[F] = List.empty[VerifiedEpics[F, F, Unit]]
+  ) extends SignalProcCommand[F] {
+    private def addParam(p: VerifiedEpics[F, F, Unit]): SignalProcCommand[F] =
+      SignalProcCommandImpl(telltale, channels, timeout, params :+ p)
+
+    override def post: VerifiedEpics[F, F, ApplyCommandResult] =
+      params.compile *> writeChannel(telltale, channels.detSigInitDir)(
+        CadDirective.START.pure[F]
+      ) *>
+        VerifiedEpics.liftF(Temporal[F].sleep(commandWaitTime).as(ApplyCommandResult.Completed))
+
+    override def filename(name: String): SignalProcCommand[F] = addParam(
+      writeCadParam(telltale, channels.darkFilename)(name)
+    )
+  }
+
+  private[tcs] def buildSystem[F[_]: Monad: Temporal: Parallel](
+    wfsChannels:   WfsChannels[F],
+    oiwfsChannels: OiwfsChannels[F]
+  ): OiwfsEpicsSystem[F] = new OiwfsEpicsSystem[F] {
+    private val wfsEpicsSystem: WfsEpicsSystem[F] = WfsEpicsSystem.buildSystem[F](wfsChannels)
+
+    export wfsEpicsSystem.*
+
+    override def startDarkCommand(timeout: FiniteDuration): DarkCommand[F] =
+      new DarkCommandImpl[F](wfsChannels.telltale, oiwfsChannels, timeout)
+
+    override def startClosedLoopCommand(timeout: FiniteDuration): ClosedLoopCommand[F] =
+      ClosedLoopCommandImpl[F](wfsChannels.telltale, oiwfsChannels, timeout)
+
+    override def startSignalProcCommand(timeout: FiniteDuration): SignalProcCommand[F] =
+      SignalProcCommandImpl[F](wfsChannels.telltale, oiwfsChannels, timeout)
+
+  }
+
+  val systemName: String = "OIWFS"
+
+  def build[F[_]: Dispatcher: Temporal: Parallel](
+    service:      EpicsService[F],
+    top:          NonEmptyString,
+    fluxName:     NonEmptyString,
+    centroidName: NonEmptyString
+  ): Resource[F, OiwfsEpicsSystem[F]] = for {
+    wfsc <- WfsChannels.build(service,
+                              systemName,
+                              top,
+                              "dc:seeing.VAL".refined,
+                              "dc:initSigInitFgGain.PROC".refined,
+                              fluxName,
+                              centroidName
+            )
+    oic  <- OiwfsChannels.build(service, top)
+  } yield buildSystem(wfsc, oic)
+
+}

--- a/modules/server/src/test/scala/navigate/server/tcs/TestOiwfsEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestOiwfsEpicsSystem.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.tcs
+
+import cats.Applicative
+import cats.Monad
+import cats.Parallel
+import cats.effect.Ref
+import cats.effect.Temporal
+import monocle.Focus
+import navigate.epics.TestChannel
+import navigate.server.acm.CadDirective
+
+object TestOiwfsEpicsSystem {
+  case class State(
+    detSigModeSeqDarkDir: TestChannel.State[CadDirective],
+    seqDarkFilename:      TestChannel.State[String],
+    detSigModeSeqDir:     TestChannel.State[CadDirective],
+    z2m2:                 TestChannel.State[String],
+    detSigInitDir:        TestChannel.State[CadDirective],
+    darkFilename:         TestChannel.State[String]
+  )
+
+  val defaultState: State = State(
+    TestChannel.State.default,
+    TestChannel.State.default,
+    TestChannel.State.default,
+    TestChannel.State.default,
+    TestChannel.State.default,
+    TestChannel.State.default
+  )
+
+  def buildChannels[F[_]: Applicative](s: Ref[F, State]): OiwfsChannels[F] = OiwfsChannels(
+    detSigModeSeqDarkDir = TestChannel(s, Focus[State](_.detSigModeSeqDarkDir)),
+    seqDarkFilename = TestChannel(s, Focus[State](_.seqDarkFilename)),
+    detSigModeSeqDir = TestChannel(s, Focus[State](_.detSigModeSeqDir)),
+    z2m2 = TestChannel(s, Focus[State](_.z2m2)),
+    detSigInitDir = TestChannel(s, Focus[State](_.detSigInitDir)),
+    darkFilename = TestChannel(s, Focus[State](_.darkFilename))
+  )
+
+  def build[F[_]: Monad: Temporal: Parallel](
+    wfs:   Ref[F, TestWfsEpicsSystem.State],
+    oiwfs: Ref[F, State]
+  ): OiwfsEpicsSystem[F] =
+    OiwfsEpicsSystem.buildSystem(TestWfsEpicsSystem.buildChannels("OIWFS", wfs),
+                                 buildChannels(oiwfs)
+    )
+
+}


### PR DESCRIPTION
Previous implementation set all OIWFS configuration through TCS, but it seems that some parts don't work. The solution was to copy the implementation from TCC, where those parts of the configuration are set directly on OIWFS. 