### PR TITLE
Fixed background file name for OIWFS.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
@@ -518,12 +518,12 @@ class TcsBaseControllerEpics[F[_]: Async: Parallel: Temporal](
     }
 
   def darkFileName(prefix: String, exposureTime: TimeSpan): String =
-    if (exposureTime > TimeSpan.unsafeFromMicroseconds(1000))
-      s"${prefix}_${math.round(1000.0 / exposureTime.toSeconds.toDouble)}mHz.fits"
+    if (exposureTime > TimeSpan.unsafeFromMicroseconds(1000000))
+      s"${prefix}${math.round(1000.0 / exposureTime.toSeconds.toDouble)}mHz.fits"
     else
-      s"${prefix}_${math.round(1.0 / exposureTime.toSeconds.toDouble)}Hz.fits"
+      s"${prefix}${math.round(1.0 / exposureTime.toSeconds.toDouble)}Hz.fits"
 
-  val oiPrefix: String = "oi"
+  val oiPrefix: String = "data/"
 
   def setupOiwfsObserve(exposureTime: TimeSpan, isQL: Boolean): F[ApplyCommandResult] =
     stateRef.get.flatMap { st =>

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -886,8 +886,9 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
     }
   }
 
-  test("Start OIWFS exposures") {
-    val testVal = TimeSpan.unsafeFromMicroseconds(12345)
+  test("Start OIWFS readout") {
+    val testVal          = TimeSpan.unsafeFromMicroseconds(5000)
+    val expectedFilename = "data/200Hz.fits"
 
     for {
       x        <- createController
@@ -895,6 +896,7 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       _        <- st.tcs.update(_.focus(_.guideStatus).replace(defaultGuideState))
       _        <- ctr.oiwfsObserve(testVal)
       rs       <- st.tcs.get
+      ois      <- st.oi.get
     } yield {
       assert(rs.oiWfs.observe.path.connected)
       assert(rs.oiWfs.observe.label.connected)
@@ -911,10 +913,11 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
         .flatMap(_.toDoubleOption)
         .map(assertEqualsDouble(_, testVal.toSeconds.toDouble, 1e-6))
         .getOrElse(fail("No interval value set"))
+      assertEquals(ois.darkFilename.value, expectedFilename.some)
     }
   }
 
-  test("Stop OIWFS exposures") {
+  test("Stop OIWFS readout") {
     for {
       x        <- createController
       (st, ctr) = x


### PR DESCRIPTION
OIWFS setup was failing because Navigate was setting the wrong file name. Fixed.