### PR TITLE
SC-4685 Changed the decoding logic for WFS centroid status.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/tcs/WfsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/WfsEpicsSystem.scala
@@ -54,7 +54,7 @@ object WfsEpicsSystem {
         VerifiedEpics.readChannel(channels.telltale, channels.flux)
       override val centroidDetected: VerifiedEpics[F, F, Boolean] = VerifiedEpics
         .readChannel(channels.telltale, channels.centroidDetected)
-        .flatMap(x => VerifiedEpics.liftF[F, F, Boolean](x.map(_ =!= 0)))
+        .flatMap(x => VerifiedEpics.liftF[F, F, Boolean](x.map(_ === 1)))
     }
   }
 

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -1083,7 +1083,7 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
     val testGuideQuality = GuidersQualityValues(
       GuidersQualityValues.GuiderQuality(1000, true),
       GuidersQualityValues.GuiderQuality(500, false),
-      GuidersQualityValues.GuiderQuality(1500, true)
+      GuidersQualityValues.GuiderQuality(1500, false)
     )
     for {
       x        <- createController()
@@ -1091,19 +1091,19 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       _        <- st.p1.update(
                     _.copy(
                       flux = TestChannel.State.of(testGuideQuality.pwfs1.flux),
-                      centroid = TestChannel.State.of(testGuideQuality.pwfs1.centroidDetected.fold(1, 0))
+                      centroid = TestChannel.State.of(1)
                     )
                   )
       _        <- st.p2.update(
                     _.copy(
                       flux = TestChannel.State.of(testGuideQuality.pwfs2.flux),
-                      centroid = TestChannel.State.of(testGuideQuality.pwfs2.centroidDetected.fold(1, 0))
+                      centroid = TestChannel.State.of(0)
                     )
                   )
       _        <- st.oiw.update(
                     _.copy(
                       flux = TestChannel.State.of(testGuideQuality.oiwfs.flux),
-                      centroid = TestChannel.State.of(testGuideQuality.oiwfs.centroidDetected.fold(1, 0))
+                      centroid = TestChannel.State.of(65536)
                     )
                   )
       g        <- ctr.getGuideQuality


### PR DESCRIPTION
The EPICS channel for the WFS centroid detection status can have a value of 65536, which must be interpreted as `false`, but Navigate was using the standard convestion from Int to Boolean.
As a side note, the TCL code converts any value but 1 to false.