### PR TITLE
SC-5265 Increased GACQ offset timeout.

### DIFF
--- a/modules/schema-util/src/main/scala/edu/gemini/schema/util/SchemaStitcher.scala
+++ b/modules/schema-util/src/main/scala/edu/gemini/schema/util/SchemaStitcher.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package edu.gemini.schema.util

--- a/modules/schema-util/src/main/scala/edu/gemini/schema/util/SourceResolver.scala
+++ b/modules/schema-util/src/main/scala/edu/gemini/schema/util/SourceResolver.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package edu.gemini.schema.util

--- a/modules/schema-util/src/main/scala/edu/gemini/schema/util/package.scala
+++ b/modules/schema-util/src/main/scala/edu/gemini/schema/util/package.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package edu.gemini.schema

--- a/modules/schema-util/src/test/scala/edu/gemini/schema/util/SchemaStitcherTest.scala
+++ b/modules/schema-util/src/test/scala/edu/gemini/schema/util/SchemaStitcherTest.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package edu.gemini.schema.util

--- a/modules/server/src/clue/scala/navigate/queries/ObsQueriesGQL.scala
+++ b/modules/server/src/clue/scala/navigate/queries/ObsQueriesGQL.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package navigate.queries

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
@@ -1131,6 +1131,9 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
     .post
     .verifiedRun(ConnectionTimeout)
 
+  val SettleTime: FiniteDuration    = FiniteDuration.apply(1, TimeUnit.SECONDS)
+  val AcqAdjTimeout: FiniteDuration = FiniteDuration.apply(10, TimeUnit.SECONDS)
+
   private def applyAcquisitionAdj(
     offset: Offset,
     ipa:    Option[Angle],
@@ -1167,9 +1170,7 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
            .post
        } else VerifiedEpics.pureF(ApplyCommandResult.Completed)).verifiedRun(ConnectionTimeout) <*
       (if (Math.abs(size) > 1e-6 || (ipa.isDefined && iaa.isDefined))
-         sys.tcsEpics.status.waitInPosition(FiniteDuration.apply(1, TimeUnit.SECONDS),
-                                            FiniteDuration.apply(5, TimeUnit.SECONDS)
-         )
+         sys.tcsEpics.status.waitInPosition(SettleTime, AcqAdjTimeout)
        else VerifiedEpics.unit[F, F]).verifiedRun(ConnectionTimeout)
 
   }


### PR DESCRIPTION
Tests showed that guide loops were not closed because offset configuration was failing with a timeout error. Offset was applied correctly, but takes more than the 5 seconds used as timeout. Increased the timeout to 10 seconds.