### PR TITLE
Added needed default port

### DIFF
--- a/deploy/conf/staging-gn/site.conf
+++ b/deploy/conf/staging-gn/site.conf
@@ -15,6 +15,10 @@ web-server {
     external-base-url = "navigate.hi.gemini.edu"
     # Uri to forward requests made to /proxy to.
     proxy-base-uri = "http://localhost:4000"
+    # Interface to listen on, 0.0.0.0 listens in all interfaces, production instances should be more restrictive
+    host = "0.0.0.0"
+    # Port to serve https requests
+    port = 9090
     # Certificate
     tls {
         key-store = "conf/local/site.jks"

--- a/deploy/conf/staging-gs/site.conf
+++ b/deploy/conf/staging-gs/site.conf
@@ -15,6 +15,10 @@ web-server {
     external-base-url = "navigate.cl.gemini.edu"
     # Uri to forward requests made to /proxy to.
     proxy-base-uri = "http://localhost:4000"
+    # Interface to listen on, 0.0.0.0 listens in all interfaces, production instances should be more restrictive
+    host = "0.0.0.0"
+    # Port to serve https requests
+    port = 9090
     # Certificate
     tls {
         key-store = "conf/local/site.jks"


### PR DESCRIPTION
Navigate server default port is 9070 which is restricted by IT networks, 9090 is allowed.
I am modifying the configs to start using 9090 port by default.