### PR TITLE
SC-4215 Avoid reconfiguring AO when in the right position.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/epicsdata/AgMechPosition.scala
+++ b/modules/server/src/main/scala/navigate/server/epicsdata/AgMechPosition.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.epicsdata
+
+import lucuma.core.util.Enumerated
+
+enum AgMechPosition(val tag: String) derives Enumerated {
+  case In      extends AgMechPosition("IN")
+  case Out     extends AgMechPosition("OUT")
+  case Parked  extends AgMechPosition("park-pos.")
+  case Unknown extends AgMechPosition("")
+}

--- a/modules/server/src/main/scala/navigate/server/tcs/AgsChannels.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/AgsChannels.scala
@@ -15,13 +15,17 @@ case class AgsChannels[F[_]](
   inPosition:      Channel[F, Int],
   sfParked:        Channel[F, Int],
   aoParked:        Channel[F, Int],
+  hwParked:        Channel[F, Int],
   p1Parked:        Channel[F, Int],
   p1Follow:        Channel[F, String],
   p2Parked:        Channel[F, Int],
   p2Follow:        Channel[F, String],
   oiParked:        Channel[F, Int],
   oiFollow:        Channel[F, String],
-  instrumentPorts: AgsChannels.InstrumentPortChannels[F]
+  instrumentPorts: AgsChannels.InstrumentPortChannels[F],
+  aoName:          Channel[F, String],
+  hwName:          Channel[F, String],
+  sfName:          Channel[F, String]
 )
 
 object AgsChannels {
@@ -78,6 +82,7 @@ object AgsChannels {
     inPos    <- service.getChannel[Int](top, "inPosition.VAL")
     sfParked <- service.getChannel[Int](top, "sfParked.VAL")
     aoParked <- service.getChannel[Int](top, "aoParked.VAL")
+    hwParked <- service.getChannel[Int](top, "hwParked.VAL")
     p1Parked <- service.getChannel[Int](top, "p1:probeParked.VAL")
     p1Follow <- service.getChannel[String](top, "p1:followS.VAL")
     p2Parked <- service.getChannel[Int](top, "p2:probeParked.VAL")
@@ -85,17 +90,24 @@ object AgsChannels {
     oiParked <- service.getChannel[Int](top, "oi:probeParked.VAL")
     oiFollow <- service.getChannel[String](top, "oi:followS.VAL")
     ports    <- InstrumentPortChannels.build(service, top)
+    aoName   <- service.getChannel[String](top, "aoName")
+    hwName   <- service.getChannel[String](top, "hwName")
+    sfName   <- service.getChannel[String](top, "sfName")
   } yield AgsChannels(
     t,
     inPos,
     sfParked,
     aoParked,
+    hwParked,
     p1Parked,
     p1Follow,
     p2Parked,
     p2Follow,
     oiParked,
     oiFollow,
-    ports
+    ports,
+    aoName,
+    hwName,
+    sfName
   )
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/ScienceFold.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/ScienceFold.scala
@@ -13,6 +13,7 @@ sealed trait ScienceFold extends Product with Serializable
 object ScienceFold {
   case object Parked                                                             extends ScienceFold
   final case class Position(source: LightSource, sink: LightSinkName, port: Int) extends ScienceFold
+  final case class Generic(name: String)                                         extends ScienceFold
 
   given Eq[Position] = Eq.by(x => (x.source, x.sink, x.port))
 

--- a/modules/server/src/test/scala/navigate/server/tcs/TestAgsEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestAgsEpicsSystem.scala
@@ -18,6 +18,7 @@ object TestAgsEpicsSystem {
     inPosition: TestChannel.State[Int],
     sfParked:   TestChannel.State[Int],
     aoParked:   TestChannel.State[Int],
+    hwParked:   TestChannel.State[Int],
     p1Parked:   TestChannel.State[Int],
     p1Follow:   TestChannel.State[String],
     p2Parked:   TestChannel.State[Int],
@@ -31,12 +32,16 @@ object TestAgsEpicsSystem {
     gpiPort:    TestChannel.State[Int],
     gsaoiPort:  TestChannel.State[Int],
     nifsPort:   TestChannel.State[Int],
-    niriPort:   TestChannel.State[Int]
+    niriPort:   TestChannel.State[Int],
+    aoName:     TestChannel.State[String],
+    hwName:     TestChannel.State[String],
+    sfName:     TestChannel.State[String]
   )
 
   val defaultState: State = State(
     TestChannel.State.of(""),
     TestChannel.State.of(0),
+    TestChannel.State.of(1),
     TestChannel.State.of(1),
     TestChannel.State.of(1),
     TestChannel.State.of(1),
@@ -52,7 +57,10 @@ object TestAgsEpicsSystem {
     TestChannel.State.of(5),
     TestChannel.State.of(0),
     TestChannel.State.of(0),
-    TestChannel.State.of(0)
+    TestChannel.State.of(0),
+    TestChannel.State.of(""),
+    TestChannel.State.of(""),
+    TestChannel.State.of("")
   )
 
   def buildChannels[F[_]: Temporal](
@@ -63,6 +71,7 @@ object TestAgsEpicsSystem {
     inPosition = new TestChannel[F, State, Int](s, Focus[State](_.inPosition)),
     sfParked = new TestChannel[F, State, Int](s, Focus[State](_.sfParked)),
     aoParked = new TestChannel[F, State, Int](s, Focus[State](_.aoParked)),
+    hwParked = new TestChannel[F, State, Int](s, Focus[State](_.hwParked)),
     p1Parked = new TestChannel[F, State, Int](s, Focus[State](_.p1Parked)),
     p1Follow = new TestChannel[F, State, String](s, Focus[State](_.p1Follow)),
     p2Parked = new TestChannel[F, State, Int](s, Focus[State](_.p2Parked)),
@@ -78,7 +87,10 @@ object TestAgsEpicsSystem {
       gnirs = new TestChannel[F, State, Int](s, Focus[State](_.gnirsPort)),
       nifs = new TestChannel[F, State, Int](s, Focus[State](_.nifsPort)),
       ghost = new TestChannel[F, State, Int](s, Focus[State](_.ghostPort))
-    )
+    ),
+    aoName = new TestChannel[F, State, String](s, Focus[State](_.aoName)),
+    hwName = new TestChannel[F, State, String](s, Focus[State](_.hwName)),
+    sfName = new TestChannel[F, State, String](s, Focus[State](_.sfName))
   )
 
   def build[F[_]: {Temporal, Parallel}](

--- a/modules/server/src/test/scala/navigate/server/tcs/TestTcsEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestTcsEpicsSystem.scala
@@ -36,6 +36,7 @@ import navigate.server.tcs.TcsChannels.PointingModelAdjustChannels
 import navigate.server.tcs.TcsChannels.ProbeChannels
 import navigate.server.tcs.TcsChannels.ProbeGuideModeChannels
 import navigate.server.tcs.TcsChannels.ProbeTrackingChannels
+import navigate.server.tcs.TcsChannels.ProbeTrackingStateChannels
 import navigate.server.tcs.TcsChannels.RotatorChannels
 import navigate.server.tcs.TcsChannels.SlewChannels
 import navigate.server.tcs.TcsChannels.TargetChannels
@@ -91,6 +92,13 @@ object TestTcsEpicsSystem {
   case class ProbeState(
     parkDir: TestChannel.State[CadDirective],
     follow:  TestChannel.State[String]
+  )
+
+  case class ProbeTrackingStateState(
+    nodAchopA: TestChannel.State[String],
+    nodAchopB: TestChannel.State[String],
+    nodBchopA: TestChannel.State[String],
+    nodBchopB: TestChannel.State[String]
   )
 
   case class SlewChannelsState(
@@ -223,49 +231,54 @@ object TestTcsEpicsSystem {
   }
 
   case class State(
-    telltale:         TestChannel.State[String],
-    telescopeParkDir: TestChannel.State[CadDirective],
-    mountFollow:      TestChannel.State[String],
-    rotStopBrake:     TestChannel.State[String],
-    rotParkDir:       TestChannel.State[CadDirective],
-    rotFollow:        TestChannel.State[String],
-    rotMoveAngle:     TestChannel.State[String],
-    enclosure:        EnclosureChannelsState,
-    sourceA:          TargetChannelsState,
-    oiwfsTarget:      TargetChannelsState,
-    wavelSourceA:     TestChannel.State[String],
-    slew:             SlewChannelsState,
-    rotator:          RotatorChannelState,
-    origin:           OriginChannelState,
-    focusOffset:      TestChannel.State[String],
-    pwfs1Tracking:    ProbeTrackingState,
-    pwfs2Tracking:    ProbeTrackingState,
-    oiwfsTracking:    ProbeTrackingState,
-    oiwfsProbe:       ProbeState,
-    oiWfs:            WfsChannelState,
-    aowfsTracking:    ProbeTrackingState,
-    m1Guide:          TestChannel.State[String],
-    m1GuideConfig:    M1GuideConfigState,
-    m2Guide:          TestChannel.State[String],
-    m2GuideMode:      TestChannel.State[String],
-    m2GuideConfig:    M2GuideConfigState,
-    m2GuideReset:     TestChannel.State[CadDirective],
-    m2Follow:         TestChannel.State[String],
-    mountGuide:       MountGuideState,
-    guideStatus:      GuideConfigState,
-    probeGuideMode:   ProbeGuideModeState,
-    oiwfsSelect:      OiwfsSelectState,
-    m2Baffles:        M2BafflesState,
-    hrwfsMech:        AgMechState,
-    scienceFoldMech:  AgMechState,
-    aoFoldMech:       AgMechState,
-    m1Cmds:           M1CommandsState,
-    nodState:         TestChannel.State[String],
-    targetAdjust:     AdjustCommandState,
-    originAdjust:     AdjustCommandState,
-    pointingAdjust:   PointingAdjustCommandState,
-    inPosition:       TestChannel.State[String],
-    targetFilter:     TargetFilterCommandState
+    telltale:           TestChannel.State[String],
+    telescopeParkDir:   TestChannel.State[CadDirective],
+    mountFollow:        TestChannel.State[String],
+    rotStopBrake:       TestChannel.State[String],
+    rotParkDir:         TestChannel.State[CadDirective],
+    rotFollow:          TestChannel.State[String],
+    rotMoveAngle:       TestChannel.State[String],
+    enclosure:          EnclosureChannelsState,
+    sourceA:            TargetChannelsState,
+    oiwfsTarget:        TargetChannelsState,
+    wavelSourceA:       TestChannel.State[String],
+    slew:               SlewChannelsState,
+    rotator:            RotatorChannelState,
+    origin:             OriginChannelState,
+    focusOffset:        TestChannel.State[String],
+    pwfs1Tracking:      ProbeTrackingState,
+    pwfs1Probe:         ProbeState,
+    pwfs2Tracking:      ProbeTrackingState,
+    pwfs2Probe:         ProbeState,
+    oiwfsTracking:      ProbeTrackingState,
+    oiwfsProbe:         ProbeState,
+    oiWfs:              WfsChannelState,
+    m1Guide:            TestChannel.State[String],
+    m1GuideConfig:      M1GuideConfigState,
+    m2Guide:            TestChannel.State[String],
+    m2GuideMode:        TestChannel.State[String],
+    m2GuideConfig:      M2GuideConfigState,
+    m2GuideReset:       TestChannel.State[CadDirective],
+    m2Follow:           TestChannel.State[String],
+    mountGuide:         MountGuideState,
+    guideStatus:        GuideConfigState,
+    probeGuideMode:     ProbeGuideModeState,
+    oiwfsSelect:        OiwfsSelectState,
+    m2Baffles:          M2BafflesState,
+    hrwfsMech:          AgMechState,
+    scienceFoldMech:    AgMechState,
+    aoFoldMech:         AgMechState,
+    m1Cmds:             M1CommandsState,
+    nodState:           TestChannel.State[String],
+    pwfs1TrackingState: ProbeTrackingStateState,
+    pwfs2TrackingState: ProbeTrackingStateState,
+    oiwfsTrackingState: ProbeTrackingStateState,
+    aowfsTrackingState: ProbeTrackingStateState,
+    targetAdjust:       AdjustCommandState,
+    originAdjust:       AdjustCommandState,
+    pointingAdjust:     PointingAdjustCommandState,
+    inPosition:         TestChannel.State[String],
+    targetFilter:       TargetFilterCommandState
   )
 
   val defaultState: State = State(
@@ -356,12 +369,16 @@ object TestTcsEpicsSystem {
       nodBchopA = TestChannel.State.of("Off"),
       nodBchopB = TestChannel.State.of("Off")
     ),
+    pwfs1Probe =
+      ProbeState(parkDir = TestChannel.State.default, follow = TestChannel.State.default),
     pwfs2Tracking = ProbeTrackingState(
       nodAchopA = TestChannel.State.of("Off"),
       nodAchopB = TestChannel.State.of("Off"),
       nodBchopA = TestChannel.State.of("Off"),
       nodBchopB = TestChannel.State.of("Off")
     ),
+    pwfs2Probe =
+      ProbeState(parkDir = TestChannel.State.default, follow = TestChannel.State.default),
     oiwfsTracking = ProbeTrackingState(
       nodAchopA = TestChannel.State.of("Off"),
       nodAchopB = TestChannel.State.of("Off"),
@@ -371,12 +388,6 @@ object TestTcsEpicsSystem {
     oiwfsProbe =
       ProbeState(parkDir = TestChannel.State.default, follow = TestChannel.State.default),
     oiWfs = WfsChannelState.default,
-    aowfsTracking = ProbeTrackingState(
-      nodAchopA = TestChannel.State.of("Off"),
-      nodAchopB = TestChannel.State.of("Off"),
-      nodBchopA = TestChannel.State.of("Off"),
-      nodBchopB = TestChannel.State.of("Off")
-    ),
     m1Guide = TestChannel.State.default,
     m1GuideConfig = M1GuideConfigState.default,
     m2Guide = TestChannel.State.default,
@@ -394,6 +405,30 @@ object TestTcsEpicsSystem {
     aoFoldMech = AgMechState.default,
     m1Cmds = M1CommandsState.default,
     nodState = TestChannel.State.of("A"),
+    pwfs1TrackingState = ProbeTrackingStateState(
+      nodAchopA = TestChannel.State.of("Off"),
+      nodAchopB = TestChannel.State.of("Off"),
+      nodBchopA = TestChannel.State.of("Off"),
+      nodBchopB = TestChannel.State.of("Off")
+    ),
+    pwfs2TrackingState = ProbeTrackingStateState(
+      nodAchopA = TestChannel.State.of("Off"),
+      nodAchopB = TestChannel.State.of("Off"),
+      nodBchopA = TestChannel.State.of("Off"),
+      nodBchopB = TestChannel.State.of("Off")
+    ),
+    oiwfsTrackingState = ProbeTrackingStateState(
+      nodAchopA = TestChannel.State.of("Off"),
+      nodAchopB = TestChannel.State.of("Off"),
+      nodBchopA = TestChannel.State.of("Off"),
+      nodBchopB = TestChannel.State.of("Off")
+    ),
+    aowfsTrackingState = ProbeTrackingStateState(
+      nodAchopA = TestChannel.State.of("Off"),
+      nodAchopB = TestChannel.State.of("Off"),
+      nodBchopA = TestChannel.State.of("Off"),
+      nodBchopB = TestChannel.State.of("Off")
+    ),
     targetAdjust = AdjustCommandState.default,
     originAdjust = AdjustCommandState.default,
     pointingAdjust = PointingAdjustCommandState.default,
@@ -523,6 +558,16 @@ object TestTcsEpicsSystem {
     new TestChannel[F, State, String](s, l.andThen(Focus[ProbeTrackingState](_.nodAchopB))),
     new TestChannel[F, State, String](s, l.andThen(Focus[ProbeTrackingState](_.nodBchopA))),
     new TestChannel[F, State, String](s, l.andThen(Focus[ProbeTrackingState](_.nodBchopB)))
+  )
+
+  def buildProbeTrackingStateChannels[F[_]: Temporal](
+    s: Ref[F, State],
+    l: Lens[State, ProbeTrackingStateState]
+  ): ProbeTrackingStateChannels[F] = ProbeTrackingStateChannels(
+    new TestChannel[F, State, String](s, l.andThen(Focus[ProbeTrackingStateState](_.nodAchopA))),
+    new TestChannel[F, State, String](s, l.andThen(Focus[ProbeTrackingStateState](_.nodAchopB))),
+    new TestChannel[F, State, String](s, l.andThen(Focus[ProbeTrackingStateState](_.nodBchopA))),
+    new TestChannel[F, State, String](s, l.andThen(Focus[ProbeTrackingStateState](_.nodBchopB)))
   )
 
   def buildProbeChannels[F[_]: Temporal](
@@ -914,6 +959,10 @@ object TestTcsEpicsSystem {
       rotator = buildRotatorChannels(s),
       origin = buildOriginChannels(s),
       focusOffset = new TestChannel[F, State, String](s, Focus[State](_.focusOffset)),
+      p1ProbeTracking = buildProbeTrackingChannels(s, Focus[State](_.pwfs1Tracking)),
+      p1Probe = buildProbeChannels(s, Focus[State](_.pwfs1Probe)),
+      p2ProbeTracking = buildProbeTrackingChannels(s, Focus[State](_.pwfs2Tracking)),
+      p2Probe = buildProbeChannels(s, Focus[State](_.pwfs2Probe)),
       oiProbeTracking = buildProbeTrackingChannels(s, Focus[State](_.oiwfsTracking)),
       oiProbe = buildProbeChannels(s, Focus[State](_.oiwfsProbe)),
       m1Guide = new TestChannel[F, State, String](s, Focus[State](_.m1Guide)),
@@ -934,10 +983,10 @@ object TestTcsEpicsSystem {
       aoFoldMech = buildAgMechChannels(s, Focus[State](_.aoFoldMech)),
       m1Channels = buildM1Channels(s, Focus[State](_.m1Cmds)),
       nodState = new TestChannel[F, State, String](s, Focus[State](_.nodState)),
-      p1ProbeTrackingState = buildProbeTrackingChannels(s, Focus[State](_.pwfs1Tracking)),
-      p2ProbeTrackingState = buildProbeTrackingChannels(s, Focus[State](_.pwfs2Tracking)),
-      oiProbeTrackingState = buildProbeTrackingChannels(s, Focus[State](_.oiwfsTracking)),
-      aoProbeTrackingState = buildProbeTrackingChannels(s, Focus[State](_.aowfsTracking)),
+      p1ProbeTrackingState = buildProbeTrackingStateChannels(s, Focus[State](_.pwfs1TrackingState)),
+      p2ProbeTrackingState = buildProbeTrackingStateChannels(s, Focus[State](_.pwfs2TrackingState)),
+      oiProbeTrackingState = buildProbeTrackingStateChannels(s, Focus[State](_.oiwfsTrackingState)),
+      aoProbeTrackingState = buildProbeTrackingStateChannels(s, Focus[State](_.aowfsTrackingState)),
       targetAdjust = buildAdjustChannels(s, Focus[State](_.targetAdjust)),
       originAdjust = buildAdjustChannels(s, Focus[State](_.originAdjust)),
       pointingAdjust = buildPointingAdjustChannels(s, Focus[State](_.pointingAdjust)),


### PR DESCRIPTION
I added checks to avoid reconfiguring the AO fold, science fold or AC pick-off mirror if they are already in the required position.