### PR TITLE
SC-5063 Removed references to non-existent AO tracking channels.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/tcs/TcsChannels.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsChannels.scala
@@ -63,7 +63,6 @@ case class TcsChannels[F[_]](
   p1ProbeTrackingState: ProbeTrackingStateChannels[F],
   p2ProbeTrackingState: ProbeTrackingStateChannels[F],
   oiProbeTrackingState: ProbeTrackingStateChannels[F],
-  aoProbeTrackingState: ProbeTrackingStateChannels[F],
   targetAdjust:         AdjustChannels[F],
   originAdjust:         AdjustChannels[F],
   pointingAdjust:       PointingModelAdjustChannels[F],
@@ -762,7 +761,6 @@ object TcsChannels {
       p1gs <- buildProbeTrackingStateChannels(service, tcsTop, "Pwfs1")
       p2gs <- buildProbeTrackingStateChannels(service, tcsTop, "Pwfs2")
       oigs <- buildProbeTrackingStateChannels(service, tcsTop, "Oiwfs")
-      aogs <- buildProbeTrackingStateChannels(service, tcsTop, "Aowfs")
       inpo <- service.getChannel[String](tcsTop.value, "sad:inPosition.VAL")
       tf   <- TargetFilterChannels.build(service, tcsTop)
     } yield TcsChannels[F](
@@ -808,7 +806,6 @@ object TcsChannels {
       p1gs,
       p2gs,
       oigs,
-      aogs,
       trad,
       orad,
       pmad,

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
@@ -209,7 +209,6 @@ object TcsEpicsSystem {
     val pwfs1ProbeGuideState: ProbeGuideState[F]
     val pwfs2ProbeGuideState: ProbeGuideState[F]
     val oiwfsProbeGuideState: ProbeGuideState[F]
-    val aowfsProbeGuideState: ProbeGuideState[F]
     // // This functions returns a F that, when run, first waits tcsSettleTime to absorb in-position transients, then waits
     // // for the in-position to change to true and stay true for stabilizationTime. It will wait up to `timeout`
     // // seconds for that to happen.
@@ -360,8 +359,6 @@ object TcsEpicsSystem {
           buildProbeGuideState(channels.telltale, channels.p2ProbeTrackingState)
         override val oiwfsProbeGuideState: ProbeGuideState[F]       =
           buildProbeGuideState(channels.telltale, channels.oiProbeTrackingState)
-        override val aowfsProbeGuideState: ProbeGuideState[F]       =
-          buildProbeGuideState(channels.telltale, channels.aoProbeTrackingState)
 
         private val tcsSettleTime = FiniteDuration(2800, MILLISECONDS)
         override def waitInPosition(

--- a/modules/server/src/test/scala/navigate/server/tcs/TestTcsEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestTcsEpicsSystem.scala
@@ -273,7 +273,6 @@ object TestTcsEpicsSystem {
     pwfs1TrackingState: ProbeTrackingStateState,
     pwfs2TrackingState: ProbeTrackingStateState,
     oiwfsTrackingState: ProbeTrackingStateState,
-    aowfsTrackingState: ProbeTrackingStateState,
     targetAdjust:       AdjustCommandState,
     originAdjust:       AdjustCommandState,
     pointingAdjust:     PointingAdjustCommandState,
@@ -418,12 +417,6 @@ object TestTcsEpicsSystem {
       nodBchopB = TestChannel.State.of("Off")
     ),
     oiwfsTrackingState = ProbeTrackingStateState(
-      nodAchopA = TestChannel.State.of("Off"),
-      nodAchopB = TestChannel.State.of("Off"),
-      nodBchopA = TestChannel.State.of("Off"),
-      nodBchopB = TestChannel.State.of("Off")
-    ),
-    aowfsTrackingState = ProbeTrackingStateState(
       nodAchopA = TestChannel.State.of("Off"),
       nodAchopB = TestChannel.State.of("Off"),
       nodBchopA = TestChannel.State.of("Off"),
@@ -986,7 +979,6 @@ object TestTcsEpicsSystem {
       p1ProbeTrackingState = buildProbeTrackingStateChannels(s, Focus[State](_.pwfs1TrackingState)),
       p2ProbeTrackingState = buildProbeTrackingStateChannels(s, Focus[State](_.pwfs2TrackingState)),
       oiProbeTrackingState = buildProbeTrackingStateChannels(s, Focus[State](_.oiwfsTrackingState)),
-      aoProbeTrackingState = buildProbeTrackingStateChannels(s, Focus[State](_.aowfsTrackingState)),
       targetAdjust = buildAdjustChannels(s, Focus[State](_.targetAdjust)),
       originAdjust = buildAdjustChannels(s, Focus[State](_.originAdjust)),
       pointingAdjust = buildPointingAdjustChannels(s, Focus[State](_.pointingAdjust)),


### PR DESCRIPTION
Sky operation failed when trying to reference AO tracking command.
There are no AO tracking channels. The logic is a bit more complicated, the AO tracking command is the same that is used for PWFS2.