### PR TITLE
SC-5063 fixed sky target file name.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
@@ -676,7 +676,7 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
     else
       s"${prefix}${math.round(1.0 / exposureTime.toSeconds.toDouble)}Hz.fits"
 
-  val oiPrefix: String = "data/"
+  val dataFolderName: String = "data/"
 
   def setupOiwfsObserve(exposureTime: TimeSpan, isQL: Boolean): F[ApplyCommandResult] =
     stateRef.get.flatMap { st =>
@@ -685,7 +685,7 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
 
       val setSigProc  = expTimeChange
         .map(t =>
-          sys.oiwfs.startSignalProcCommand(timeout).filename(darkFileName(oiPrefix, t)).post
+          sys.oiwfs.startSignalProcCommand(timeout).filename(darkFileName(dataFolderName, t)).post
         )
         .getOrElse(VerifiedEpics.pureF[F, F, ApplyCommandResult](ApplyCommandResult.Completed)) *>
         qlChange
@@ -868,7 +868,7 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
                     .verifiedRun(ConnectionTimeout) *> Temporal[F].sleep(postStopDelay)).whenA(oiActive)
       _        <- sys.oiwfs
                     .startDarkCommand(timeout)
-                    .filename(darkFileName(oiPrefix, exposureTime))
+                    .filename(darkFileName("", exposureTime))
                     .post
                     .verifiedRun(ConnectionTimeout) *> Temporal[F].sleep(postDarkConfigDelay)
       ret      <- sys.tcsEpics

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -1622,7 +1622,7 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       r2       <- st.oi.get
     } yield {
       assert(r2.seqDarkFilename.connected)
-      assertEquals(r2.seqDarkFilename.value, "data/20Hz.fits".some)
+      assertEquals(r2.seqDarkFilename.value, "20Hz.fits".some)
 
       assert(r1.m1Guide.connected)
       assert(r1.m1GuideConfig.source.connected)


### PR DESCRIPTION
There was a difference between the file name parameter set to take the background image and the one set to read the image for processing. The former didn't need the "data/" folder prefix. 