### PR TITLE
SC-6186 Added support for OI, P1 and P2 reference frames for handsets.

### DIFF
--- a/modules/model/src/main/scala/navigate/model/HandsetAdjustment.scala
+++ b/modules/model/src/main/scala/navigate/model/HandsetAdjustment.scala
@@ -3,6 +3,7 @@
 
 package navigate.model
 
+import lucuma.core.enums.GuideProbe
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 
@@ -13,4 +14,6 @@ object HandsetAdjustment {
   case class FocalPlaneAdjustment(value: FocalPlaneOffset)         extends HandsetAdjustment
   case class InstrumentAdjustment(value: Offset)                   extends HandsetAdjustment
   case class EquatorialAdjustment(deltaRA: Angle, deltaDec: Angle) extends HandsetAdjustment
+  case class ProbeFrameAdjustment(probeRefFrame: GuideProbe, deltaX: Angle, deltaY: Angle)
+      extends HandsetAdjustment
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
@@ -9,6 +9,7 @@ import cats.effect.Ref
 import cats.effect.Temporal
 import cats.syntax.all.*
 import lucuma.core.enums.ComaOption
+import lucuma.core.enums.GuideProbe
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.LightSinkName
 import lucuma.core.enums.M1Source
@@ -57,6 +58,7 @@ import navigate.server.epicsdata.AgMechPosition
 import navigate.server.epicsdata.BinaryOnOff
 import navigate.server.epicsdata.BinaryYesNo
 import navigate.server.tcs.AcquisitionCameraEpicsSystem.*
+import navigate.server.tcs.AgsEpicsSystem.PwfsAngles
 import navigate.server.tcs.ParkStatus.NotParked
 import navigate.server.tcs.Target.*
 import navigate.server.tcs.TcsEpicsSystem.BaseWfsCommands
@@ -1727,82 +1729,118 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
         )
     }
 
-  private def adjustParams(handsetAdjustment: HandsetAdjustment): (ReferenceFrame, Double, Angle) =
+  private def wfsRefAdjustParams(
+    st:  PwfsAngles[F],
+    pol: (Angle, Angle)
+  ): F[(ReferenceFrame, Double, Angle)] = (
+    for {
+      tableAngleF <- st.tableAngle
+      armAngleF   <- st.armAngle
+    } yield for {
+      tableAngle <- tableAngleF
+      armAngle   <- armAngleF
+    } yield (ReferenceFrame.XY,
+             pol._1.toSignedDoubleDegrees * DegreesToArcseconds,
+             pol._2 + tableAngle + armAngle
+    )
+  ).verifiedRun(ConnectionTimeout)
+
+  private val OiwfsAngle: Angle = Angle.fromDoubleDegrees(138.94)
+
+  private def adjustParams(
+    handsetAdjustment: HandsetAdjustment
+  ): F[(ReferenceFrame, Double, Angle)] =
     handsetAdjustment match {
-      case HandsetAdjustment.EquatorialAdjustment(deltaRA, deltaDec) =>
+      case HandsetAdjustment.EquatorialAdjustment(deltaRA, deltaDec)             =>
         val pol = rectToPolar(deltaRA, deltaDec)
         (ReferenceFrame.Tracking, pol._1.toSignedDoubleDegrees * DegreesToArcseconds, pol._2)
-      case HandsetAdjustment.FocalPlaneAdjustment(value)             =>
+          .pure[F]
+      case HandsetAdjustment.FocalPlaneAdjustment(value)                         =>
         val pol = rectToPolar(value.deltaX.value, value.deltaY.value)
-        (ReferenceFrame.XY, pol._1.toSignedDoubleDegrees * DegreesToArcseconds, pol._2)
-      case HandsetAdjustment.HorizontalAdjustment(deltaAz, deltaEl)  =>
+        (ReferenceFrame.XY, pol._1.toSignedDoubleDegrees * DegreesToArcseconds, pol._2).pure[F]
+      case HandsetAdjustment.HorizontalAdjustment(deltaAz, deltaEl)              =>
         val pol = rectToPolar(deltaAz, deltaEl)
         (ReferenceFrame.AzimuthElevation,
          pol._1.toSignedDoubleDegrees * DegreesToArcseconds,
          pol._2
-        )
-      case HandsetAdjustment.InstrumentAdjustment(value)             =>
+        ).pure[F]
+      case HandsetAdjustment.InstrumentAdjustment(value)                         =>
         val pol = rectToPolar(-value.q.toAngle, value.p.toAngle)
         (ReferenceFrame.Instrument, pol._1.toSignedDoubleDegrees * DegreesToArcseconds, pol._2)
+          .pure[F]
+      case HandsetAdjustment.ProbeFrameAdjustment(probeRefFrame, deltaX, deltaY) =>
+        val pol = rectToPolar(deltaX, deltaY)
+        probeRefFrame match {
+          case GuideProbe.PWFS1           => wfsRefAdjustParams(sys.ags.status.pwfs1Angles, pol)
+          case GuideProbe.PWFS2           => wfsRefAdjustParams(sys.ags.status.pwfs2Angles, pol)
+          case GuideProbe.GmosOIWFS       =>
+            (ReferenceFrame.XY,
+             pol._1.toSignedDoubleDegrees * DegreesToArcseconds,
+             pol._2 + OiwfsAngle
+            ).pure[F]
+          case GuideProbe.Flamingos2OIWFS =>
+            (ReferenceFrame.XY,
+             pol._1.toSignedDoubleDegrees * DegreesToArcseconds,
+             pol._2 + OiwfsAngle
+            ).pure[F]
+        }
     }
 
   override def targetAdjust(
     target:            VirtualTelescope,
     handsetAdjustment: HandsetAdjustment,
     openLoops:         Boolean
-  )(guide: GuideConfig): F[ApplyCommandResult] = {
-    val (frame, size, angle) = adjustParams(handsetAdjustment)
-
+  )(guide: GuideConfig): F[ApplyCommandResult] =
     pauseGuide.whenA(openLoops) *>
-      sys.tcsEpics
-        .startCommand(timeout)
-        .targetAdjustCommand
-        .frame(frame)
-        .targetAdjustCommand
-        .size(size)
-        .targetAdjustCommand
-        .angle(angle)
-        .targetAdjustCommand
-        .vtMask(List(target))
-        .post
-        .verifiedRun(ConnectionTimeout) <*
+      adjustParams(handsetAdjustment).flatMap { case (frame, size, angle) =>
+        sys.tcsEpics
+          .startCommand(timeout)
+          .targetAdjustCommand
+          .frame(frame)
+          .targetAdjustCommand
+          .size(size)
+          .targetAdjustCommand
+          .angle(angle)
+          .targetAdjustCommand
+          .vtMask(List(target))
+          .post
+          .verifiedRun(ConnectionTimeout)
+      } <*
       resumeGuide(guide.tcsGuide).whenA(openLoops)
-  }
 
   override def originAdjust(handsetAdjustment: HandsetAdjustment, openLoops: Boolean)(
     guide: GuideConfig
-  ): F[ApplyCommandResult] = {
-    val (frame, size, angle) = adjustParams(handsetAdjustment)
-
+  ): F[ApplyCommandResult] =
     pauseGuide.whenA(openLoops) *>
+      adjustParams(handsetAdjustment).flatMap { case (frame, size, angle) =>
+        sys.tcsEpics
+          .startCommand(timeout)
+          .originAdjustCommand
+          .frame(frame)
+          .originAdjustCommand
+          .size(size)
+          .originAdjustCommand
+          .angle(angle)
+          .originAdjustCommand
+          .vtMask(List(VirtualTelescope.SourceA))
+          .post
+          .verifiedRun(ConnectionTimeout)
+      } <*
+      resumeGuide(guide.tcsGuide).whenA(openLoops)
+
+  override def pointingAdjust(handsetAdjustment: HandsetAdjustment): F[ApplyCommandResult] =
+    adjustParams(handsetAdjustment).flatMap { case (frame, size, angle) =>
       sys.tcsEpics
         .startCommand(timeout)
-        .originAdjustCommand
+        .pointingAdjustCommand
         .frame(frame)
-        .originAdjustCommand
+        .pointingAdjustCommand
         .size(size)
-        .originAdjustCommand
+        .pointingAdjustCommand
         .angle(angle)
-        .originAdjustCommand
-        .vtMask(List(VirtualTelescope.SourceA))
         .post
-        .verifiedRun(ConnectionTimeout) <*
-      resumeGuide(guide.tcsGuide).whenA(openLoops)
-  }
-
-  override def pointingAdjust(handsetAdjustment: HandsetAdjustment): F[ApplyCommandResult] = {
-    val (frame, size, angle) = adjustParams(handsetAdjustment)
-    sys.tcsEpics
-      .startCommand(timeout)
-      .pointingAdjustCommand
-      .frame(frame)
-      .pointingAdjustCommand
-      .size(size)
-      .pointingAdjustCommand
-      .angle(angle)
-      .post
-      .verifiedRun(ConnectionTimeout)
-  }
+        .verifiedRun(ConnectionTimeout)
+    }
 
   override def targetOffsetAbsorb(target: VirtualTelescope): F[ApplyCommandResult] = {
     val selection: OffsetIndexSelection = target match {

--- a/modules/server/src/test/scala/navigate/server/tcs/TestAgsEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestAgsEpicsSystem.scala
@@ -13,28 +13,32 @@ import navigate.server.tcs.AgsChannels.InstrumentPortChannels
 object TestAgsEpicsSystem {
 
   case class State(
-    telltale:   TestChannel.State[String],
-    inPosition: TestChannel.State[Int],
-    sfParked:   TestChannel.State[Int],
-    aoParked:   TestChannel.State[Int],
-    hwParked:   TestChannel.State[Int],
-    p1Parked:   TestChannel.State[Int],
-    p1Follow:   TestChannel.State[String],
-    p2Parked:   TestChannel.State[Int],
-    p2Follow:   TestChannel.State[String],
-    oiParked:   TestChannel.State[Int],
-    oiFollow:   TestChannel.State[String],
-    f2Port:     TestChannel.State[Int],
-    ghostPort:  TestChannel.State[Int],
-    gmosPort:   TestChannel.State[Int],
-    gnirsPort:  TestChannel.State[Int],
-    gpiPort:    TestChannel.State[Int],
-    gsaoiPort:  TestChannel.State[Int],
-    nifsPort:   TestChannel.State[Int],
-    niriPort:   TestChannel.State[Int],
-    aoName:     TestChannel.State[String],
-    hwName:     TestChannel.State[String],
-    sfName:     TestChannel.State[String]
+    telltale:     TestChannel.State[String],
+    inPosition:   TestChannel.State[Int],
+    sfParked:     TestChannel.State[Int],
+    aoParked:     TestChannel.State[Int],
+    hwParked:     TestChannel.State[Int],
+    p1Parked:     TestChannel.State[Int],
+    p1Follow:     TestChannel.State[String],
+    p2Parked:     TestChannel.State[Int],
+    p2Follow:     TestChannel.State[String],
+    oiParked:     TestChannel.State[Int],
+    oiFollow:     TestChannel.State[String],
+    f2Port:       TestChannel.State[Int],
+    ghostPort:    TestChannel.State[Int],
+    gmosPort:     TestChannel.State[Int],
+    gnirsPort:    TestChannel.State[Int],
+    gpiPort:      TestChannel.State[Int],
+    gsaoiPort:    TestChannel.State[Int],
+    nifsPort:     TestChannel.State[Int],
+    niriPort:     TestChannel.State[Int],
+    aoName:       TestChannel.State[String],
+    hwName:       TestChannel.State[String],
+    sfName:       TestChannel.State[String],
+    p1TableAngle: TestChannel.State[Double],
+    p1ArmAngle:   TestChannel.State[Double],
+    p2TableAngle: TestChannel.State[Double],
+    p2ArmAngle:   TestChannel.State[Double]
   )
 
   val defaultState: State = State(
@@ -59,7 +63,11 @@ object TestAgsEpicsSystem {
     TestChannel.State.of(0),
     TestChannel.State.of(""),
     TestChannel.State.of(""),
-    TestChannel.State.of("")
+    TestChannel.State.of(""),
+    TestChannel.State.of(0.0),
+    TestChannel.State.of(0.0),
+    TestChannel.State.of(0.0),
+    TestChannel.State.of(0.0)
   )
 
   def buildChannels[F[_]: Temporal](
@@ -89,7 +97,15 @@ object TestAgsEpicsSystem {
     ),
     aoName = new TestChannel[F, State, String](s, Focus[State](_.aoName)),
     hwName = new TestChannel[F, State, String](s, Focus[State](_.hwName)),
-    sfName = new TestChannel[F, State, String](s, Focus[State](_.sfName))
+    sfName = new TestChannel[F, State, String](s, Focus[State](_.sfName)),
+    p1Angles = AgsChannels.PwfsAnglesChannels[F](
+      tableAngle = new TestChannel[F, State, Double](s, Focus[State](_.p1TableAngle)),
+      armAngle = new TestChannel[F, State, Double](s, Focus[State](_.p1ArmAngle))
+    ),
+    p2Angles = AgsChannels.PwfsAnglesChannels[F](
+      tableAngle = new TestChannel[F, State, Double](s, Focus[State](_.p2TableAngle)),
+      armAngle = new TestChannel[F, State, Double](s, Focus[State](_.p2ArmAngle))
+    )
   )
 
   def build[F[_]: Temporal](

--- a/modules/web/server/src/main/resources/navigate.graphql
+++ b/modules/web/server/src/main/resources/navigate.graphql
@@ -309,6 +309,12 @@ input EquatorialOffsetInput {
     deltaDec: AngleInput!
 }
 
+input ProbeFrameOffsetInput {
+    probeFrame: GuideProbe!
+    deltaX: AngleInput!
+    deltaY: AngleInput!
+}
+
 input HandsetAdjustmentInput {
     """ Azimuth/Elevation coordinate system """
     horizontalAdjustment: HorizontalOffsetInput
@@ -318,6 +324,8 @@ input HandsetAdjustmentInput {
     instrumentAdjustment: OffsetInput
     """ Right Ascension/Declination coordinate system """
     equatorialAdjustment: EquatorialOffsetInput
+    """ Offset applied in one of the probe's reference frame """
+    probeFrameAdjustment: ProbeFrameOffsetInput
 }
 
 type PointingCorrections {

--- a/modules/web/server/src/main/scala/navigate/web/server/http4s/NavigateMappings.scala
+++ b/modules/web/server/src/main/scala/navigate/web/server/http4s/NavigateMappings.scala
@@ -1352,6 +1352,14 @@ object NavigateMappings extends GrackleParsers {
           dra  <- n.collectFirst { case ("deltaRA", ObjectValue(m)) => parseAngle(m) }.flatten
           ddec <- n.collectFirst { case ("deltaDec", ObjectValue(m)) => parseAngle(m) }.flatten
         } yield HandsetAdjustment.EquatorialAdjustment(dra, ddec)
+      case Some(("probeFrameAdjustment", ObjectValue(n))) =>
+        for {
+          probe <- n.collectFirst { case ("probeFrame", EnumValue(name)) =>
+                     parseEnumerated[GuideProbe](name)
+                   }.flatten
+          dx    <- n.collectFirst { case ("deltaX", ObjectValue(m)) => parseAngle(m) }.flatten
+          dy    <- n.collectFirst { case ("deltaY", ObjectValue(m)) => parseAngle(m) }.flatten
+        } yield HandsetAdjustment.ProbeFrameAdjustment(probe, dx, dy)
       case _                                              => none
     }
 

--- a/modules/web/server/src/test/scala/navigate/web/server/http4s/NavigateMappingsSuite.scala
+++ b/modules/web/server/src/test/scala/navigate/web/server/http4s/NavigateMappingsSuite.scala
@@ -1668,11 +1668,33 @@ class NavigateMappingsSuite extends CatsEffectSuite {
           |}
           |""".stripMargin
             )
+      t  <- mp.compileAndRun(
+              """
+          |mutation {
+          |  adjustPointing(
+          |    offset: {
+          |      probeFrameAdjustment: {
+          |        probeFrame: GMOS_OIWFS
+          |        deltaX: {
+          |          arcseconds: 0.1
+          |        }
+          |        deltaY: {
+          |          arcseconds: 0.0
+          |        }
+          |      }
+          |    }
+          |  ) {
+          |    result
+          |  }
+          |}
+          |""".stripMargin
+            )
     } yield {
       assertEquals(checkResult(p), "SUCCESS".some)
       assertEquals(checkResult(q), "SUCCESS".some)
       assertEquals(checkResult(r), "SUCCESS".some)
       assertEquals(checkResult(s), "SUCCESS".some)
+      assertEquals(checkResult(t), "SUCCESS".some)
     }
   }
 


### PR DESCRIPTION
Support for offsets applied on the OI, P1 and P2 reference frame, usually applied while looking at the corresponding guider image feed (as opposite to looking at the acquisition camera image)