### PR TITLE
Simulated different ports for GN and GS.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
+++ b/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
@@ -624,6 +624,7 @@ object NavigateEngine {
           case Instrument.Gnirs      => x.gnirsPort
           case Instrument.Gpi        => x.gpiPort
           case Instrument.Gsaoi      => x.gsaoiPort
+          case Instrument.Igrins2    => x.igrins2Port
           case Instrument.Niri       => x.niriPort
           case Instrument.Alopeke    => (site === Site.GN).fold(2, 0)
           case Instrument.Zorro      => (site === Site.GS).fold(2, 0)

--- a/modules/server/src/main/scala/navigate/server/tcs/AgsChannels.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/AgsChannels.scala
@@ -34,14 +34,15 @@ object AgsChannels {
   val sysName: String = "AGS"
 
   case class InstrumentPortChannels[F[_]](
-    gmos:  Channel[F, Int],
-    gsaoi: Channel[F, Int],
-    gpi:   Channel[F, Int],
-    f2:    Channel[F, Int],
-    niri:  Channel[F, Int],
-    gnirs: Channel[F, Int],
-    nifs:  Channel[F, Int],
-    ghost: Channel[F, Int]
+    gmos:    Channel[F, Int],
+    gsaoi:   Channel[F, Int],
+    gpi:     Channel[F, Int],
+    f2:      Channel[F, Int],
+    niri:    Channel[F, Int],
+    gnirs:   Channel[F, Int],
+    nifs:    Channel[F, Int],
+    ghost:   Channel[F, Int],
+    igrins2: Channel[F, Int]
   )
 
   object InstrumentPortChannels {
@@ -62,6 +63,7 @@ object AgsChannels {
         gn <- buildPortCh("nirs")
         nf <- buildPortCh("nifs")
         gh <- buildPortCh("ghost")
+        ig <- buildPortCh("igrins2")
       } yield InstrumentPortChannels(
         gm,
         gs,
@@ -70,7 +72,8 @@ object AgsChannels {
         nr,
         gn,
         nf,
-        gh
+        gh,
+        ig
       )
     }
 

--- a/modules/server/src/main/scala/navigate/server/tcs/AgsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/AgsEpicsSystem.scala
@@ -45,6 +45,7 @@ object AgsEpicsSystem {
     def gnirsPort: VerifiedEpics[F, F, Int]
     def gpiPort: VerifiedEpics[F, F, Int]
     def gsaoiPort: VerifiedEpics[F, F, Int]
+    def igrins2Port: VerifiedEpics[F, F, Int]
     def nifsPort: VerifiedEpics[F, F, Int]
     def niriPort: VerifiedEpics[F, F, Int]
     def aoName: VerifiedEpics[F, F, AgMechPosition]
@@ -125,6 +126,9 @@ object AgsEpicsSystem {
         override def gsaoiPort: VerifiedEpics[F, F, Int] =
           VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.gsaoi)
 
+        override def igrins2Port: VerifiedEpics[F, F, Int] =
+          VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.igrins2)
+
         override def nifsPort: VerifiedEpics[F, F, Int] =
           VerifiedEpics.readChannel(channels.telltale, channels.instrumentPorts.nifs)
 
@@ -158,7 +162,10 @@ object AgsEpicsSystem {
   }
 
   object PwfsAngles {
-    def build[F[_]: Applicative](tt: TelltaleChannel[F], chs: AgsChannels.PwfsAnglesChannels[F]) =
+    def build[F[_]: Applicative](
+      tt:  TelltaleChannel[F],
+      chs: AgsChannels.PwfsAnglesChannels[F]
+    ): PwfsAngles[F] =
       new PwfsAngles[F] {
         override val tableAngle: VerifiedEpics[F, F, Angle] = VerifiedEpics
           .readChannel[F, Double](tt, chs.tableAngle)

--- a/modules/server/src/main/scala/navigate/server/tcs/InstrumentPorts.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/InstrumentPorts.scala
@@ -10,6 +10,7 @@ case class InstrumentPorts(
   gnirsPort:      Int,
   gpiPort:        Int,
   gsaoiPort:      Int,
+  igrins2Port:    Int,
   nifsPort:       Int,
   niriPort:       Int
 )

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
@@ -183,6 +183,7 @@ class TcsBaseControllerSim[F[_]: Sync](
       gnirsPort = 0,
       gpiPort = 0,
       gsaoiPort = 5,
+      igrins2Port = 0,
       nifsPort = 0,
       niriPort = 0
     ).pure[F]

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsNorthControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsNorthControllerEpics.scala
@@ -27,12 +27,14 @@ class TcsNorthControllerEpics[F[_]: {Async, Parallel, Logger}](
     gmF <- sys.ags.status.gmosPort
     gnF <- sys.ags.status.gnirsPort
     gpF <- sys.ags.status.gpiPort
+    igF <- sys.ags.status.igrins2Port
     nfF <- sys.ags.status.nifsPort
     nrF <- sys.ags.status.niriPort
   } yield for {
     gm <- gmF
     gn <- gnF
     gp <- gpF
+    ig <- igF
     nf <- nfF
     nr <- nrF
   } yield InstrumentPorts(
@@ -42,6 +44,7 @@ class TcsNorthControllerEpics[F[_]: {Async, Parallel, Logger}](
     gnirsPort = gn,
     gpiPort = gp,
     gsaoiPort = 0,
+    igrins2Port = ig,
     nifsPort = nf,
     niriPort = nr
   )).verifiedRun(ConnectionTimeout)

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsNorthControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsNorthControllerSim.scala
@@ -24,6 +24,7 @@ class TcsNorthControllerSim[F[_]: Sync](
       gnirsPort = 3,
       gpiPort = 0,
       gsaoiPort = 0,
+      igrins2Port = 0,
       nifsPort = 1,
       niriPort = 0
     ).pure[F]

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerEpics.scala
@@ -40,6 +40,7 @@ class TcsSouthControllerEpics[F[_]: {Async, Parallel, Logger}](
     gnirsPort = 0,
     gpiPort = 0,
     gsaoiPort = gs,
+    igrins2Port = 0,
     nifsPort = 0,
     niriPort = 0
   )).verifiedRun(ConnectionTimeout)

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerSim.scala
@@ -23,6 +23,7 @@ class TcsSouthControllerSim[F[_]: Sync](
       gnirsPort = 0,
       gpiPort = 0,
       gsaoiPort = 5,
+      igrins2Port = 0,
       nifsPort = 0,
       niriPort = 0
     ).pure[F]

--- a/modules/server/src/test/scala/navigate/server/tcs/TestAgsEpicsSystem.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TestAgsEpicsSystem.scala
@@ -30,6 +30,7 @@ object TestAgsEpicsSystem {
     gnirsPort:    TestChannel.State[Int],
     gpiPort:      TestChannel.State[Int],
     gsaoiPort:    TestChannel.State[Int],
+    igrins2Port:  TestChannel.State[Int],
     nifsPort:     TestChannel.State[Int],
     niriPort:     TestChannel.State[Int],
     aoName:       TestChannel.State[String],
@@ -55,6 +56,7 @@ object TestAgsEpicsSystem {
     TestChannel.State.of(""),
     TestChannel.State.of(1),
     TestChannel.State.of(3),
+    TestChannel.State.of(0),
     TestChannel.State.of(0),
     TestChannel.State.of(0),
     TestChannel.State.of(5),
@@ -93,7 +95,8 @@ object TestAgsEpicsSystem {
       niri = new TestChannel[F, State, Int](s, Focus[State](_.niriPort)),
       gnirs = new TestChannel[F, State, Int](s, Focus[State](_.gnirsPort)),
       nifs = new TestChannel[F, State, Int](s, Focus[State](_.nifsPort)),
-      ghost = new TestChannel[F, State, Int](s, Focus[State](_.ghostPort))
+      ghost = new TestChannel[F, State, Int](s, Focus[State](_.ghostPort)),
+      igrins2 = new TestChannel[F, State, Int](s, Focus[State](_.igrins2Port))
     ),
     aoName = new TestChannel[F, State, String](s, Focus[State](_.aoName)),
     hwName = new TestChannel[F, State, String](s, Focus[State](_.hwName)),


### PR DESCRIPTION
This should fix the problem getting the right instrument configuration in the Heroku instance of Navigate.