### PR TITLE
SC-6350 Write origin parameter in the right units.

### DIFF
--- a/modules/model/src/main/scala/navigate/model/Origin.scala
+++ b/modules/model/src/main/scala/navigate/model/Origin.scala
@@ -4,15 +4,15 @@
 package navigate.model
 
 import cats.Show
-import navigate.model.Distance
+import lucuma.core.math.Angle
 
 case class Origin(
-  x: Distance,
-  y: Distance
+  x: Angle,
+  y: Angle
 )
 
 object Origin {
   given Show[Origin] = Show.show { o =>
-    f"Origin(x: ${o.x.toMillimeters.value.toDouble}%.2f, y: ${o.y.toMillimeters.value.toDouble}%.2f)"
+    f"Origin(x: ${Angle.signedDecimalArcseconds.get(o.x).toDouble}%.2f, y: ${Angle.signedDecimalArcseconds.get(o.y).toDouble}%.2f)"
   }
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsEpicsSystem.scala
@@ -483,12 +483,16 @@ object TcsEpicsSystem {
                         FocalPlaneOffset.DeltaY(Angle.fromDoubleRadians(v(3)))
                       ),
                       FocalPlaneOffset(
-                        FocalPlaneOffset.DeltaX(Angle.fromDoubleRadians(v(4)) * FocalPlaneScale),
-                        FocalPlaneOffset.DeltaY(Angle.fromDoubleRadians(v(5)) * FocalPlaneScale)
+                        FocalPlaneOffset
+                          .DeltaX(Distance.fromBigDecimalMillimeter(v(4)).toAngleInFocalPlane),
+                        FocalPlaneOffset
+                          .DeltaY(Distance.fromBigDecimalMillimeter(v(5)).toAngleInFocalPlane)
                       ),
                       FocalPlaneOffset(
-                        FocalPlaneOffset.DeltaX(Angle.fromDoubleRadians(v(6)) * FocalPlaneScale),
-                        FocalPlaneOffset.DeltaY(Angle.fromDoubleRadians(v(7)) * FocalPlaneScale)
+                        FocalPlaneOffset
+                          .DeltaX(Distance.fromBigDecimalMillimeter(v(6)).toAngleInFocalPlane),
+                        FocalPlaneOffset
+                          .DeltaY(Distance.fromBigDecimalMillimeter(v(7)).toAngleInFocalPlane)
                       )
                     ).pure[F]
                   }
@@ -835,21 +839,21 @@ object TcsEpicsSystem {
 
     override val originCommand: OriginCommand[F, TcsCommands[F]] =
       new OriginCommand[F, TcsCommands[F]] {
-        override def originX(v: Distance): TcsCommands[F] =
+        override def originX(v: Angle): TcsCommands[F] =
           addMultipleParams(
             List(
-              tcsEpics.originCmd.setParam1(v.toMillimeters.value.toDouble),
-              tcsEpics.originCmd.setParam3(v.toMillimeters.value.toDouble),
-              tcsEpics.originCmd.setParam5(v.toMillimeters.value.toDouble)
+              tcsEpics.originCmd.setParam1(v.toLengthInFocalPlane.toMillimeters.value.toDouble),
+              tcsEpics.originCmd.setParam3(v.toLengthInFocalPlane.toMillimeters.value.toDouble),
+              tcsEpics.originCmd.setParam5(v.toLengthInFocalPlane.toMillimeters.value.toDouble)
             )
           )
 
-        override def originY(v: Distance): TcsCommands[F] =
+        override def originY(v: Angle): TcsCommands[F] =
           addMultipleParams(
             List(
-              tcsEpics.originCmd.setParam2(v.toMillimeters.value.toDouble),
-              tcsEpics.originCmd.setParam4(v.toMillimeters.value.toDouble),
-              tcsEpics.originCmd.setParam6(v.toMillimeters.value.toDouble)
+              tcsEpics.originCmd.setParam2(v.toLengthInFocalPlane.toMillimeters.value.toDouble),
+              tcsEpics.originCmd.setParam4(v.toLengthInFocalPlane.toMillimeters.value.toDouble),
+              tcsEpics.originCmd.setParam6(v.toLengthInFocalPlane.toMillimeters.value.toDouble)
             )
           )
       }
@@ -1950,8 +1954,8 @@ object TcsEpicsSystem {
   }
 
   trait OriginCommand[F[_], +S] {
-    def originX(v: Distance): S
-    def originY(v: Distance): S
+    def originX(v: Angle): S
+    def originY(v: Angle): S
   }
 
   trait FocusOffsetCommand[F[_], +S] {

--- a/modules/server/src/main/scala/navigate/server/tcs/package.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/package.scala
@@ -8,11 +8,13 @@ import cats.Monad
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.LightSinkName
+import lucuma.core.math.Angle
 import lucuma.core.util.NewType
 import navigate.epics.Channel
 import navigate.epics.EpicsSystem.TelltaleChannel
 import navigate.epics.VerifiedEpics.VerifiedEpics
 import navigate.epics.VerifiedEpics.writeChannel
+import navigate.model.Distance
 import navigate.server.acm.CadDirective
 import navigate.server.acm.Encoder
 import navigate.server.acm.writeCadParam
@@ -215,4 +217,14 @@ extension (i: Instrument) {
     case _                     => LightSinkName.Ac
 }
 
-val FocalPlaneScale: Double = 1.61144 // arcsec/mm
+private val FocalPlaneScale: Double = 1.61144 // arcsec/mm
+
+extension (a: Angle) {
+  def toLengthInFocalPlane: Distance =
+    Distance.fromBigDecimalMillimeter(Angle.signedDecimalArcseconds.get(a) / FocalPlaneScale)
+}
+
+extension (d: Distance) {
+  def toAngleInFocalPlane: Angle =
+    Angle.fromBigDecimalArcseconds(d.toMillimeters.value * FocalPlaneScale)
+}

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -304,7 +304,7 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       iaa = Angle.fromDoubleDegrees(123.45),
       focusOffset = Distance.fromLongMicrometers(2344),
       agName = "gmos",
-      origin = Origin(Distance.fromLongMicrometers(4567), Distance.fromLongMicrometers(-8901))
+      origin = Origin(Angle.fromMicroarcseconds(4567), Angle.fromMicroarcseconds(-8901))
     )
 
     for {
@@ -415,32 +415,50 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       )
       assert(
         rs.origin.xa.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.x.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.x.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.xb.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.x.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.x.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.xc.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.x.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.x.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.ya.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.y.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.y.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.yb.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.y.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.y.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.yc.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.y.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.y.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
 
@@ -467,7 +485,7 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       iaa = Angle.fromDoubleDegrees(123.45),
       focusOffset = Distance.fromLongMicrometers(2344),
       agName = "gmos",
-      origin = Origin(Distance.fromLongMicrometers(4567), Distance.fromLongMicrometers(-8901))
+      origin = Origin(Angle.fromMicroarcseconds(4567), Angle.fromMicroarcseconds(-8901))
     )
 
     for {
@@ -488,32 +506,50 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
       )
       assert(
         rs.origin.xa.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.x.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.x.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.xb.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.x.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.x.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.xc.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.x.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.x.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.ya.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.y.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.y.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.yb.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.y.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.y.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
       assert(
         rs.origin.yc.value.exists(x =>
-          compareDouble(x.toDouble, instrumentSpecifics.origin.y.toMillimeters.value.toDouble)
+          compareDouble(
+            x.toDouble,
+            instrumentSpecifics.origin.y.toLengthInFocalPlane.toMillimeters.value.toDouble
+          )
         )
       )
     }

--- a/modules/web/server/src/main/resources/navigate.graphql
+++ b/modules/web/server/src/main/resources/navigate.graphql
@@ -35,13 +35,13 @@ input AzElTargetInput {
 }
 
 type PointOrigin {
-    x: Distance!
-    y: Distance!
+    x: Angle!
+    y: Angle!
 }
 
 input PointOriginInput {
-    x: DistanceInput!
-    y: DistanceInput!
+    x: AngleInput!
+    y: AngleInput!
 }
 
 input InstrumentSpecificsInput {

--- a/modules/web/server/src/main/scala/navigate/web/server/http4s/NavigateMappings.scala
+++ b/modules/web/server/src/main/scala/navigate/web/server/http4s/NavigateMappings.scala
@@ -1218,8 +1218,8 @@ object NavigateMappings extends GrackleParsers {
   } yield TrackingConfig(aa, ab, ba, bb)
 
   def parseOrigin(l: List[(String, Value)]): Option[Origin] = for {
-    x <- l.collectFirst { case ("x", ObjectValue(v)) => parseDistance(v) }.flatten
-    y <- l.collectFirst { case ("y", ObjectValue(v)) => parseDistance(v) }.flatten
+    x <- l.collectFirst { case ("x", ObjectValue(v)) => parseAngle(v) }.flatten
+    y <- l.collectFirst { case ("y", ObjectValue(v)) => parseAngle(v) }.flatten
   } yield Origin(x, y)
 
   def parseInstrumentSpecificsInput(l: List[(String, Value)]): Option[InstrumentSpecifics] = for {

--- a/modules/web/server/src/test/scala/navigate/web/server/http4s/NavigateMappingsSuite.scala
+++ b/modules/web/server/src/test/scala/navigate/web/server/http4s/NavigateMappingsSuite.scala
@@ -174,10 +174,10 @@ class NavigateMappingsSuite extends CatsEffectSuite {
                 |      agName: "gmos"
                 |      origin: {
                 |        x: {
-                |          micrometers: 3012
+                |          milliarcseconds: 3012
                 |        }
                 |        y: {
-                |          micrometers: -1234
+                |          milliarcseconds: -1234
                 |        }
                 |      }
                 |    }
@@ -271,10 +271,10 @@ class NavigateMappingsSuite extends CatsEffectSuite {
                 |      agName: "gmos"
                 |      origin: {
                 |        x: {
-                |          micrometers: 3012
+                |          milliarcseconds: 3012
                 |        }
                 |        y: {
-                |          micrometers: -1234
+                |          milliarcseconds: -1234
                 |        }
                 |      }
                 |    }
@@ -367,10 +367,10 @@ class NavigateMappingsSuite extends CatsEffectSuite {
           |      agName: "gmos"
           |      origin: {
           |        x: {
-          |          micrometers: 3012
+          |          milliarcseconds: 3012
           |        }
           |        y: {
-          |          micrometers: -1234
+          |          milliarcseconds: -1234
           |        }
           |      }
           |    }
@@ -425,10 +425,10 @@ class NavigateMappingsSuite extends CatsEffectSuite {
           |    agName: "gmos"
           |    origin: {
           |      x: {
-          |        micrometers: 3012
+          |        milliarcseconds: 3012
           |      }
           |      y: {
-          |        micrometers: -1234
+          |        milliarcseconds: -1234
           |      }
           |    }
           |  }
@@ -501,10 +501,10 @@ class NavigateMappingsSuite extends CatsEffectSuite {
           |    agName: "ac"
           |    origin: {
           |      x: {
-          |        micrometers: 3012
+          |        milliarcseconds: 3012
           |      }
           |      y: {
-          |        micrometers: -1234
+          |        milliarcseconds: -1234
           |      }
           |    }
           |  }
@@ -556,10 +556,10 @@ class NavigateMappingsSuite extends CatsEffectSuite {
           |    agName: "gmos"
           |    origin: {
           |      x: {
-          |        micrometers: 3012
+          |        milliarcseconds: 3012
           |      }
           |      y: {
-          |        micrometers: -1234
+          |        milliarcseconds: -1234
           |      }
           |    }
           |  }
@@ -615,10 +615,10 @@ class NavigateMappingsSuite extends CatsEffectSuite {
                 |    agName: "Test"
                 |    origin: {
                 |      x: {
-                |        millimeters: 12.43
+                |        arcseconds: 12.43
                 |      }
                 |      y: {
-                |        millimeters: 54.54
+                |        arcseconds: 54.54
                 |      }
                 |    }
                 |}) {


### PR DESCRIPTION
Pointing origin coordinates are written as mm in TCS, but used in arcseconds in the UI. 