### PR TITLE
SC-6348 observe and stop now wait on integration flag.

### DIFF
--- a/modules/epics/src/main/scala/navigate/epics/EpicsSystem.scala
+++ b/modules/epics/src/main/scala/navigate/epics/EpicsSystem.scala
@@ -81,7 +81,7 @@ case class EpicsSystem[F[_]: {Async, Parallel}](
                   true.pure[F],
                   ch.connect(connectionTimeout).attempt.map(_.isRight)
                 )
-                .flatMap(t => ch.getName.map((_, t)))
+                .map(t => (ch.getName, t))
             )
           )
           .toList

--- a/modules/epics/src/main/scala/navigate/epics/RemoteChannel.scala
+++ b/modules/epics/src/main/scala/navigate/epics/RemoteChannel.scala
@@ -16,7 +16,7 @@ trait RemoteChannel[F[_]] {
   def connect: F[Unit]
   def connect(timeout: FiniteDuration): F[Unit]
   def disconnect: F[Unit]
-  def getName: F[String]
+  def getName: String
   def getConnectionState: F[ConnectionState]
   def getAccessRights: F[AccessRights]
 }
@@ -30,7 +30,7 @@ object RemoteChannel {
       Async[F].fromCompletableFuture(Async[F].delay(caChannel.connectAsync())).void
     override def connect(timeout: FiniteDuration): F[Unit] = connect.timeout(timeout)
     override def disconnect: F[Unit]                       = Async[F].delay(caChannel.close())
-    override def getName: F[String]                        = Async[F].delay(caChannel.getName)
+    override def getName: String                           = caChannel.getName
     override def getConnectionState: F[ConnectionState]    =
       Async[F].delay(caChannel.getConnectionState)
     override def getAccessRights: F[AccessRights]          = Async[F].delay(caChannel.getAccessRights)

--- a/modules/epics/src/main/scala/navigate/epics/TestChannel.scala
+++ b/modules/epics/src/main/scala/navigate/epics/TestChannel.scala
@@ -72,7 +72,7 @@ class TestChannel[F[_]: Temporal, S, A: Eq](s: Ref[F, S], l: Lens[S, State[A]])
 
   override def disconnect: F[Unit] = s.update(l.modify(_.copy(connected = true)))
 
-  override def getName: F[String] = "".pure[F]
+  override def getName: String = ""
 
   override def getConnectionState: F[ConnectionState] =
     s.get.map(l.get(_).connected.fold(ConnectionState.CONNECTED, ConnectionState.DISCONNECTED))

--- a/modules/server/src/main/scala/navigate/server/acm/ObserveCommand.scala
+++ b/modules/server/src/main/scala/navigate/server/acm/ObserveCommand.scala
@@ -1,0 +1,364 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package navigate.server.acm
+
+import cats.Applicative
+import cats.Eq
+import cats.derived.*
+import cats.effect.Resource
+import cats.effect.Temporal
+import cats.effect.std.Dispatcher
+import cats.effect.syntax.temporal.*
+import cats.syntax.all.*
+import fs2.RaiseThrowable.*
+import fs2.Stream
+import navigate.epics.Channel
+import navigate.epics.Channel.StreamEvent
+import navigate.epics.EpicsService
+import navigate.epics.EpicsSystem.TelltaleChannel
+import navigate.epics.VerifiedEpics.*
+import navigate.server.ApplyCommandResult
+import navigate.server.epicsdata.BinaryYesNo
+
+import scala.concurrent.duration.FiniteDuration
+
+trait ObserveCommand[F[_]] {
+  import ObserveCommand.CommandType
+
+  /**
+   * Given a pair of apply and CAR records and a observing status, this function produces a program
+   * that will trigger the apply record and then monitor the apply and CAR record to finally produce
+   * a command result. If the command takes longer than the <code>timeout</code>, it will produce an
+   * error. The program is contained in a <code>VerifiedEpics</code> that checks the connection to
+   * the channels.
+   * @param timeout
+   *   The timeout for running the command
+   * @return
+   */
+  def post(typ: CommandType, timeout: FiniteDuration): VerifiedEpics[F, F, ApplyCommandResult]
+}
+
+object ObserveCommand {
+
+  enum CommandType derives Eq {
+    case PermanentOn  extends CommandType
+    case PermanentOff extends CommandType
+    case TemporarlyOn extends CommandType
+    case NoWait       extends CommandType
+  }
+
+  enum CmdPhase {
+    case WaitingBusy extends CmdPhase
+    case WaitingIdle extends CmdPhase
+    case Done        extends CmdPhase
+  }
+
+  enum ObsPhase {
+    case WaitingOn  extends ObsPhase
+    case WaitingOff extends ObsPhase
+    case Done       extends ObsPhase
+  }
+
+  case class PostState(applyVal: Option[Int], cmdPhase: CmdPhase, obsPhase: ObsPhase)
+
+  sealed trait Event                              extends Product with Serializable
+  case class ApplyValChange(v: Int)               extends Event
+  case class CarValChange(v: CarState, clid: Int) extends Event
+  case class IntegratingValChange(v: BinaryYesNo) extends Event
+
+  private final class ObserveCommandImpl[F[_]: {Dispatcher, Temporal}](
+    telltaleChannel: TelltaleChannel[F],
+    apply:           ApplyRecord[F],
+    car:             CarRecord[F],
+    integrating:     Channel[F, BinaryYesNo]
+  ) extends ObserveCommand[F] {
+    override def post(
+      typ:     CommandType,
+      timeout: FiniteDuration
+    ): VerifiedEpics[F, F, ApplyCommandResult] = {
+      val streamsV = for {
+        avrs   <- eventStream(telltaleChannel, apply.oval)
+        cvrs   <- eventStream(telltaleChannel, car.oval)
+        dwr    <- writeChannel(telltaleChannel, apply.dir)(Applicative[F].pure(CadDirective.START))
+                    .map(Resource.pure[F, F[Unit]])
+        msrr   <- readChannel(telltaleChannel, apply.mess).map(Resource.pure[F, F[String]])
+        omsrr  <- readChannel(telltaleChannel, car.omss).map(Resource.pure[F, F[String]])
+        clidrr <- readChannel(telltaleChannel, car.clid).map(Resource.pure[F, F[Int]])
+        avrr   <- readChannel(telltaleChannel, apply.oval).map(Resource.pure[F, F[Int]])
+        intsF  <- eventStream(telltaleChannel, integrating)
+      } yield for {
+        avs   <- avrs
+        cvs   <- cvrs
+        dw    <- dwr
+        msr   <- msrr
+        omsr  <- omsrr
+        clidr <- clidrr
+        avr   <- avrr
+        ints  <- intsF
+      } yield (avs, cvs, dw, msr, omsr, clidr, avr, ints)
+
+      streamsV.map(_.use { case (avs, cvs, dw, msr, omsr, clidr, avr, ints) =>
+        processCommand(typ, avs, cvs, dw, msr, omsr, clidr, avr, ints).timeout(timeout)
+      })
+
+    }
+
+    /**
+     * processCommand is the heart of the observe command processing. It implements a state machine
+     * inside a Stream, that follows the algorithm described in Gemini ICD 1b, section 6.1, while
+     * also monitoring the integration state of the WFS. The events of the state machine are changes
+     * on the EPICS channels apply.VAL, car.VAL and the integration state channel. The monitors
+     * created by the CA library always give the current value as the first event (if there is a
+     * current value). That holds true for the Streams created from those monitors. That is the
+     * reason that apply.VAL is read at the beginning, to compare the initial value with the stream
+     * values and recognize actual changes.
+     *
+     * @param typ
+     *   : Observe operation type.
+     * @param avs
+     *   : Stream of values from apply.VAL
+     * @param cvs
+     *   : Stream of values from car.VAL
+     * @param dw
+     *   : Effect that will write a START on apply.DIR when evaluated.
+     * @param msr
+     *   : Effect to read apply.MESS
+     * @param omsr
+     *   : Effect to read car.OMSS
+     * @param clidr
+     *   : Effect to read car.CLID
+     * @param avr
+     *   : Effect to read apply.VAL
+     * @param ints
+     *   : Stream of values from the integration state channel
+     * @return
+     *   Effect that return the command result on completion.
+     */
+    private def processCommand(
+      typ:   CommandType,
+      avs:   Stream[F, StreamEvent[Int]],
+      cvs:   Stream[F, StreamEvent[CarState]],
+      dw:    F[Unit],
+      msr:   F[String],
+      omsr:  F[String],
+      clidr: F[Int],
+      avr:   F[Int],
+      ints:  Stream[F, StreamEvent[BinaryYesNo]]
+    ): F[ApplyCommandResult] = {
+      val startObsPhase = typ match {
+        case CommandType.PermanentOn  => ObsPhase.WaitingOn
+        case CommandType.PermanentOff => ObsPhase.WaitingOff
+        case CommandType.TemporarlyOn => ObsPhase.WaitingOn
+        case CommandType.NoWait       => ObsPhase.Done
+      }
+
+      def processApplyChange(v: Int, s: PostState): (PostState, F[Option[ApplyCommandResult]]) =
+        s match {
+          case u @ PostState(None, _, _) if v < 0   =>
+            (
+              u,
+              msr.flatMap(msg =>
+                new Throwable(s"Apply record ${apply.name} failed with error: $msg").raiseError
+              )
+            )
+          case u @ PostState(None, _, _) if v === 0 =>
+            (
+              u,
+              new Throwable(
+                s"Apply record ${apply.name} triggered externally while processing."
+              ).raiseError
+            )
+          case PostState(None, b, c)                =>
+            (PostState(v.some, b, c), none[ApplyCommandResult].pure[F])
+          case u                                    =>
+            (u, none[ApplyCommandResult].pure[F])
+        }
+
+      def processCarChange(
+        v:    CarState,
+        clid: Int,
+        s:    PostState
+      ): (PostState, F[Option[ApplyCommandResult]]) = s match {
+        case PostState(Some(av), CmdPhase.WaitingIdle, ObsPhase.Done)
+            if v === CarState.IDLE && clid >= av =>
+          (
+            PostState(Some(av), CmdPhase.Done, ObsPhase.Done),
+            ApplyCommandResult.Completed.some.pure[F]
+          )
+        case PostState(Some(av), CmdPhase.WaitingIdle, c) if v === CarState.IDLE && clid >= av =>
+          (
+            PostState(Some(av), CmdPhase.Done, c),
+            none[ApplyCommandResult].pure[F]
+          )
+        case PostState(a, CmdPhase.WaitingIdle, c) if v === CarState.IDLE                      =>
+          (
+            PostState(a, CmdPhase.WaitingBusy, c),
+            none[ApplyCommandResult].pure[F]
+          )
+        case PostState(a, CmdPhase.WaitingBusy, c) if v === CarState.BUSY                      =>
+          (
+            PostState(a, CmdPhase.WaitingIdle, c),
+            none[ApplyCommandResult].pure[F]
+          )
+        case PostState(Some(av), CmdPhase.WaitingIdle, ObsPhase.Done)
+            if v === CarState.ERROR && clid >= av =>
+          (
+            PostState(Some(av), CmdPhase.Done, ObsPhase.Done),
+            omsr.flatMap(msg => new Throwable(s"CAR record ${car.name} has error: $msg").raiseError)
+          )
+        case u                                                                                 =>
+          (
+            u,
+            none[ApplyCommandResult].pure[F]
+          )
+      }
+
+      def processIntegratingChange(
+        v: BinaryYesNo,
+        s: PostState
+      ): (PostState, F[Option[ApplyCommandResult]]) = typ match {
+        case CommandType.PermanentOn  =>
+          s match {
+            case PostState(a, CmdPhase.Done, ObsPhase.WaitingOn) if v === BinaryYesNo.Yes =>
+              (
+                PostState(a, CmdPhase.Done, ObsPhase.Done),
+                ApplyCommandResult.Completed.some.pure[F]
+              )
+            case PostState(a, b, ObsPhase.WaitingOn) if v === BinaryYesNo.Yes             =>
+              (
+                PostState(a, b, ObsPhase.Done),
+                none[ApplyCommandResult].pure[F]
+              )
+            case PostState(a, b, _) if v === BinaryYesNo.No                               =>
+              (
+                PostState(a, b, ObsPhase.WaitingOn),
+                none[ApplyCommandResult].pure[F]
+              )
+            case u                                                                        =>
+              (
+                u,
+                none[ApplyCommandResult].pure[F]
+              )
+          }
+        case CommandType.PermanentOff =>
+          s match {
+            case PostState(a, CmdPhase.Done, ObsPhase.WaitingOff) if v === BinaryYesNo.No =>
+              (
+                PostState(a, CmdPhase.Done, ObsPhase.Done),
+                ApplyCommandResult.Completed.some.pure[F]
+              )
+            case PostState(a, b, ObsPhase.WaitingOff) if v === BinaryYesNo.No             =>
+              (
+                PostState(a, b, ObsPhase.Done),
+                none[ApplyCommandResult].pure[F]
+              )
+            case PostState(a, b, _) if v === BinaryYesNo.Yes                              =>
+              (
+                PostState(a, b, ObsPhase.WaitingOff),
+                none[ApplyCommandResult].pure[F]
+              )
+            case u                                                                        =>
+              (
+                u,
+                none[ApplyCommandResult].pure[F]
+              )
+          }
+        case CommandType.TemporarlyOn =>
+          s match {
+            case PostState(a, CmdPhase.Done, ObsPhase.WaitingOff) if v === BinaryYesNo.No =>
+              (
+                PostState(a, CmdPhase.Done, ObsPhase.Done),
+                ApplyCommandResult.Completed.some.pure[F]
+              )
+            case PostState(a, b, ObsPhase.WaitingOff) if v === BinaryYesNo.No             =>
+              (
+                PostState(a, b, ObsPhase.Done),
+                none[ApplyCommandResult].pure[F]
+              )
+            case PostState(a, b, _) if v === BinaryYesNo.Yes                              =>
+              (
+                PostState(a, b, ObsPhase.WaitingOff),
+                none[ApplyCommandResult].pure[F]
+              )
+            case u                                                                        =>
+              (
+                u,
+                none[ApplyCommandResult].pure[F]
+              )
+          }
+        case CommandType.NoWait       =>
+          s match {
+            case u @ PostState(_, CmdPhase.Done, _) =>
+              // This should be an unreachable case
+              (
+                u,
+                new Throwable(
+                  s"Observe post should have already exited (Apply record ${apply.name}, integrating channel ${integrating.getName}."
+                ).raiseError
+              )
+            case u                                  =>
+              (
+                u,
+                none[ApplyCommandResult].pure[F]
+              )
+          }
+      }
+
+      Stream
+        .eval(avr.attempt.map(_.toOption))
+        .flatMap { avo =>
+          (
+            Stream.eval(dw) *> Stream[F, Stream[F, Event]](
+              avs.drop(avo.size).flatMap {
+                case StreamEvent.ValueChanged(v) => Stream(ApplyValChange(v))
+                case StreamEvent.Disconnected    =>
+                  Stream.raiseError[F](new Throwable(s"Apply record ${apply.name} disconnected"))
+                case _                           => Stream.empty
+              },
+              cvs.flatMap {
+                case StreamEvent.ValueChanged(v) =>
+                  Stream.eval(clidr.attempt.map(_.getOrElse(0))).map(CarValChange(v, _))
+                case StreamEvent.Disconnected    =>
+                  Stream.raiseError[F](new Throwable(s"CAR record ${apply.name} disconnected"))
+                case _                           => Stream.empty
+              },
+              ints.flatMap {
+                case StreamEvent.ValueChanged(v) => Stream(IntegratingValChange(v))
+                case StreamEvent.Disconnected    =>
+                  Stream.raiseError[F](
+                    new Throwable(s"Integrating channel ${integrating.getName} disconnected")
+                  )
+                case _                           => Stream.empty
+              }
+            ).parJoin(3)
+          ).mapAccumulate[PostState, F[Option[ApplyCommandResult]]](
+            PostState(None, CmdPhase.WaitingBusy, startObsPhase)
+          ) { (s, ev) =>
+            ev match {
+              case ApplyValChange(v)       => processApplyChange(v, s)
+              case CarValChange(v, clid)   => processCarChange(v, clid, s)
+              case IntegratingValChange(v) => processIntegratingChange(v, s)
+            }
+          }
+        }
+        .evalMap(_._2)
+        .unNone
+        .take(1)
+        .compile
+        .lastOrError
+    }
+  }
+
+  def build[F[_]: {Dispatcher, Temporal}](
+    srv:             EpicsService[F],
+    telltaleChannel: TelltaleChannel[F],
+    applyName:       String,
+    carName:         String,
+    integrating:     Channel[F, BinaryYesNo]
+  ): Resource[F, ObserveCommand[F]] = for {
+    apply <- ApplyRecord.build(srv, applyName)
+    car   <- CarRecord.build(srv, carName)
+  } yield new ObserveCommandImpl[F](telltaleChannel, apply, car, integrating)
+
+}


### PR DESCRIPTION
This PR changes the behavior of the observe and stop observe commands. The commands before returned as soon as the command was triggered in TCS. Now they wait until the WFS actually starts integrating (or stops).
I created a special function for starting and stopping the WFS. It is basically the same procedure as the one used to trigger a command in a Gemini EPICS system and monitor its execution, but this also monitors the detector status given by TCS.