### PR TITLE
SC-6430 Fixed scaling of proper motion RA component set in TCS.

### DIFF
--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
@@ -217,7 +217,10 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
         .compose[TcsCommands[F]](l.get(_).properMotion2(0.0))
         .compose[TcsCommands[F]](l.get(_).ephemerisFile(""))
     case t: SiderealTarget  =>
-      val properMotionRaScale = 1.0 / 15.0 / Math.cos(t.coordinates.dec.toRadians)
+      val properMotionRaScale =
+        if (Math.cos(t.coordinates.dec.toRadians) =!= 0.0)
+          1.0 / 15.0 / Math.cos(t.coordinates.dec.toRadians)
+        else 0.0
       { (x: TcsCommands[F]) => l.get(x).objectName(t.objectName) }
         .compose[TcsCommands[F]](l.get(_).coordSystem(SystemDefault))
         .compose[TcsCommands[F]](

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
@@ -217,6 +217,7 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
         .compose[TcsCommands[F]](l.get(_).properMotion2(0.0))
         .compose[TcsCommands[F]](l.get(_).ephemerisFile(""))
     case t: SiderealTarget  =>
+      val properMotionRaScale = 1.0 / 15.0 / Math.cos(t.coordinates.dec.toRadians)
       { (x: TcsCommands[F]) => l.get(x).objectName(t.objectName) }
         .compose[TcsCommands[F]](l.get(_).coordSystem(SystemDefault))
         .compose[TcsCommands[F]](
@@ -247,7 +248,7 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
                 .masy
                 .toUnit[ArcSecond / Year]
                 .value
-                .toDouble
+                .toDouble * properMotionRaScale
             )
         )
         .compose[TcsCommands[F]](

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -589,7 +589,7 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
     // Proper motion
     assert(
       obtained.properMotion1.value.exists(x =>
-        compareDouble(x.toDouble * 1000.0,
+        compareDouble(x.toDouble * 1000.0 * 15.0 * Math.cos(expected.coordinates.dec.toRadians),
                       expected.properMotion.map(_.ra.masy.value.toDouble).orEmpty
         )
       )


### PR DESCRIPTION
TCS expects the value as seconds/year, and as a RA rate (i.e. not scaled by cos(Dec) )