### PR TITLE
SC-6710 Fixed bad definition for AC ND filter in schema.

### DIFF
--- a/modules/model/src/main/scala/navigate/model/enums/AcFilter.scala
+++ b/modules/model/src/main/scala/navigate/model/enums/AcFilter.scala
@@ -5,7 +5,7 @@ package navigate.model.enums
 
 import lucuma.core.util.Enumerated
 
-enum AcFilter(val tag: String) extends Product with Serializable derives Enumerated {
+enum AcFilter(val tag: String) derives Enumerated {
   case Neutral extends AcFilter("Neutral")
   case U_Red1  extends AcFilter("U_Red1")
   case B_Blue  extends AcFilter("B_Blue")

--- a/modules/web/server/src/main/resources/navigate.graphql
+++ b/modules/web/server/src/main/resources/navigate.graphql
@@ -360,7 +360,7 @@ enum AcLens {
 }
 
 enum AcNdFilter {
-    Open
+    OPEN
     ND1
     ND2
     ND3

--- a/modules/web/server/src/test/scala/navigate/web/server/http4s/NavigateMappingsSuite.scala
+++ b/modules/web/server/src/test/scala/navigate/web/server/http4s/NavigateMappingsSuite.scala
@@ -2054,7 +2054,7 @@ class NavigateMappingsSuite extends CatsEffectSuite {
   }
 
   test("Query AC mechanisms state") {
-    val expected = AcMechsState(AcLens.Ac, AcNdFilter.Nd1, AcFilter.Neutral)
+    val expected = AcMechsState(AcLens.Ac, AcNdFilter.Open, AcFilter.Neutral)
     for {
       mp <- buildMapping(NavigateConfiguration.default, true)
       r  <- mp.compileAndRun(
@@ -2542,7 +2542,7 @@ object NavigateMappingsTest {
       CommandResult.CommandSuccess.pure[IO]
 
     override def getAcMechsState: IO[AcMechsState] =
-      AcMechsState(AcLens.Ac, AcNdFilter.Nd1, AcFilter.Neutral).pure[IO]
+      AcMechsState(AcLens.Ac, AcNdFilter.Open, AcFilter.Neutral).pure[IO]
 
     override def pwfs1Filter(filter: PwfsFilter): IO[CommandResult] =
       CommandResult.CommandSuccess.pure[IO]


### PR DESCRIPTION
One of the options for the AC ND Filter didn't follow the case convention in the Navigate schema.