### PR TITLE
SC-6890 AC and PWFS mechanisms now manage undefined positions

### DIFF
--- a/modules/model/src/main/scala/navigate/model/AcMechsState.scala
+++ b/modules/model/src/main/scala/navigate/model/AcMechsState.scala
@@ -10,7 +10,7 @@ import navigate.model.enums.AcLens
 import navigate.model.enums.AcNdFilter
 
 case class AcMechsState(
-  lens:     AcLens,
-  ndFilter: AcNdFilter,
-  filter:   AcFilter
+  lens:     Option[AcLens],
+  ndFilter: Option[AcNdFilter],
+  filter:   Option[AcFilter]
 ) derives Eq

--- a/modules/model/src/main/scala/navigate/model/PwfsMechsState.scala
+++ b/modules/model/src/main/scala/navigate/model/PwfsMechsState.scala
@@ -9,6 +9,6 @@ import navigate.model.enums.PwfsFieldStop
 import navigate.model.enums.PwfsFilter
 
 case class PwfsMechsState(
-  filter:    PwfsFilter,
-  fieldStop: PwfsFieldStop
+  filter:    Option[PwfsFilter],
+  fieldStop: Option[PwfsFieldStop]
 ) derives Eq

--- a/modules/server/src/main/scala/navigate/server/tcs/AgsEpicsSystem.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/AgsEpicsSystem.scala
@@ -184,8 +184,8 @@ object AgsEpicsSystem {
   }
 
   trait PwfsMechs[F[_]] {
-    val colFilter: VerifiedEpics[F, F, PwfsFilter]
-    val fieldStop: VerifiedEpics[F, F, PwfsFieldStop]
+    val colFilter: VerifiedEpics[F, F, Option[PwfsFilter]]
+    val fieldStop: VerifiedEpics[F, F, Option[PwfsFieldStop]]
   }
 
   object PwfsMechs {
@@ -193,12 +193,12 @@ object AgsEpicsSystem {
       tt:  TelltaleChannel[F],
       chs: AgsChannels.PwfsMechsChannels[F]
     ): PwfsMechs[F] = new PwfsMechs {
-      override val colFilter: VerifiedEpics[F, F, PwfsFilter]    = VerifiedEpics
+      override val colFilter: VerifiedEpics[F, F, Option[PwfsFilter]]    = VerifiedEpics
         .readChannel[F, String](tt, chs.colFilter)
-        .map(_.map(Enumerated[PwfsFilter].fromTag(_).getOrElse(PwfsFilter.Neutral)))
-      override val fieldStop: VerifiedEpics[F, F, PwfsFieldStop] = VerifiedEpics
+        .map(_.map(Enumerated[PwfsFilter].fromTag(_)))
+      override val fieldStop: VerifiedEpics[F, F, Option[PwfsFieldStop]] = VerifiedEpics
         .readChannel[F, String](tt, chs.fieldStop)
-        .map(_.map(Enumerated[PwfsFieldStop].fromTag(_).getOrElse(PwfsFieldStop.Open1)))
+        .map(_.map(Enumerated[PwfsFieldStop].fromTag(_)))
     }
   }
 

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerEpics.scala
@@ -510,11 +510,11 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
     p1f <- sys.ags.status.pwfs1Mechs.colFilter
              .verifiedRun(ConnectionTimeout)
              .attempt
-             .map(_.getOrElse(PwfsFilter.Neutral))
+             .map(_.toOption.flatten.getOrElse(PwfsFilter.Neutral))
     p2f <- sys.ags.status.pwfs2Mechs.colFilter
              .verifiedRun(ConnectionTimeout)
              .attempt
-             .map(_.getOrElse(PwfsFilter.Neutral))
+             .map(_.toOption.flatten.getOrElse(PwfsFilter.Neutral))
     r   <- (
              selectOiwfs(config) *>
                VerifiedEpics.liftF(Temporal[F].sleep(OiwfsSelectionDelay)) *>
@@ -533,11 +533,11 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
     p1f <- sys.ags.status.pwfs1Mechs.colFilter
              .verifiedRun(ConnectionTimeout)
              .attempt
-             .map(_.getOrElse(PwfsFilter.Neutral))
+             .map(_.toOption.flatten.getOrElse(PwfsFilter.Neutral))
     p2f <- sys.ags.status.pwfs2Mechs.colFilter
              .verifiedRun(ConnectionTimeout)
              .attempt
-             .map(_.getOrElse(PwfsFilter.Neutral))
+             .map(_.toOption.flatten.getOrElse(PwfsFilter.Neutral))
     r   <- (
              resetAllTracking *>
                selectOiwfsT(tcsConfig)
@@ -1574,7 +1574,7 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
           swapConfig.toTcsConfig
             .focus(_.sourceATarget)
             .andThen(Target.wavelength)
-            .replace(x.toWavelength.some)
+            .replace(x.getOrElse(AcFilter.Neutral).toWavelength.some)
         )(
           sys.tcsEpics.startCommand(TcsConfigTimeout)
         ).post
@@ -1590,11 +1590,11 @@ abstract class TcsBaseControllerEpics[F[_]: {Async, Parallel, Logger}](
       p1f <- sys.ags.status.pwfs1Mechs.colFilter
                .verifiedRun(ConnectionTimeout)
                .attempt
-               .map(_.getOrElse(PwfsFilter.Neutral))
+               .map(_.toOption.flatten.getOrElse(PwfsFilter.Neutral))
       p2f <- sys.ags.status.pwfs2Mechs.colFilter
                .verifiedRun(ConnectionTimeout)
                .attempt
-               .map(_.getOrElse(PwfsFilter.Neutral))
+               .map(_.toOption.flatten.getOrElse(PwfsFilter.Neutral))
       r   <- (selectOiwfs(config) *>
                VerifiedEpics.liftF(Temporal[F].sleep(OiwfsSelectionDelay)) *>
                applyTcsConfig(config, p1f, p2f)(sys.tcsEpics.startCommand(TcsConfigTimeout)).post)

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsBaseControllerSim.scala
@@ -319,8 +319,8 @@ abstract class TcsBaseControllerSim[F[_]: Sync](
   }
 
   override def getPwfs1Mechs: F[PwfsMechsState] =
-    PwfsMechsState(PwfsFilter.Neutral, PwfsFieldStop.Fs10).pure[F]
+    PwfsMechsState(PwfsFilter.Neutral.some, PwfsFieldStop.Fs10.some).pure[F]
 
   override def getPwfs2Mechs: F[PwfsMechsState] =
-    PwfsMechsState(PwfsFilter.Neutral, PwfsFieldStop.Fs10).pure[F]
+    PwfsMechsState(PwfsFilter.Neutral.some, PwfsFieldStop.Fs10.some).pure[F]
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsNorthControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsNorthControllerSim.scala
@@ -49,7 +49,7 @@ class TcsNorthControllerSim[F[_]: Sync](
       ApplyCommandResult.Completed.pure[F]
 
     override def getState: F[AcMechsState] =
-      AcMechsState(AcLens.Ac, AcNdFilter.Nd100, AcFilter.Neutral).pure[F]
+      AcMechsState(AcLens.Ac.some, AcNdFilter.Nd100.some, AcFilter.Neutral.some).pure[F]
   }
 
 }

--- a/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerSim.scala
+++ b/modules/server/src/main/scala/navigate/server/tcs/TcsSouthControllerSim.scala
@@ -48,7 +48,7 @@ class TcsSouthControllerSim[F[_]: Sync](
       ApplyCommandResult.Completed.pure[F]
 
     override def getState: F[AcMechsState] =
-      AcMechsState(AcLens.Ac, AcNdFilter.Nd1, AcFilter.Neutral).pure[F]
+      AcMechsState(AcLens.Ac.some, AcNdFilter.Nd1.some, AcFilter.Neutral.some).pure[F]
   }
 
 }

--- a/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
+++ b/modules/server/src/test/scala/navigate/server/tcs/TcsBaseControllerEpicsSuite.scala
@@ -2250,12 +2250,23 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
   }
 
   test("Retrieve AC mechanism positions") {
-    val result = AcMechsState(AcLens.Hrwfs, AcNdFilter.Nd1, AcFilter.Neutral)
+    val result = AcMechsState(AcLens.Hrwfs.some, AcNdFilter.Nd1.some, AcFilter.Neutral.some)
     for {
       (st, ctr) <- createController()
-      _         <- st.ac.update(_.focus(_.filterReadout.value).replace(result.filter.tag.some))
-      _         <- st.ac.update(_.focus(_.ndFilterReadout.value).replace(result.ndFilter.tag.some))
-      _         <- st.ac.update(_.focus(_.lensReadout.value).replace(result.lens.tag.some))
+      _         <- st.ac.update(_.focus(_.filterReadout.value).replace(result.filter.map(_.tag)))
+      _         <- st.ac.update(_.focus(_.ndFilterReadout.value).replace(result.ndFilter.map(_.tag)))
+      _         <- st.ac.update(_.focus(_.lensReadout.value).replace(result.lens.map(_.tag)))
+      a         <- ctr.acCommands.getState
+    } yield assertEquals(a, result)
+  }
+
+  test("Retrieve AC mechanism positions with undefined values") {
+    val result = AcMechsState(none, none, none)
+    for {
+      (st, ctr) <- createController()
+      _         <- st.ac.update(_.focus(_.filterReadout.value).replace("undefined".some))
+      _         <- st.ac.update(_.focus(_.ndFilterReadout.value).replace("undefined".some))
+      _         <- st.ac.update(_.focus(_.lensReadout.value).replace("undefined".some))
       a         <- ctr.acCommands.getState
     } yield assertEquals(a, result)
   }
@@ -2378,23 +2389,45 @@ class TcsBaseControllerEpicsSuite extends CatsEffectSuite {
   }
 
   test("Get PWFS1 mechanisms state") {
-    val v = PwfsMechsState(PwfsFilter.Red, PwfsFieldStop.Fs6_4)
+    val v = PwfsMechsState(PwfsFilter.Red.some, PwfsFieldStop.Fs6_4.some)
 
     for {
       (st, ctr) <- createController()
-      _         <- st.ags.update(_.focus(_.p1Filter.value).replace(v.filter.tag.some))
-      _         <- st.ags.update(_.focus(_.p1FieldStop.value).replace(v.fieldStop.tag.some))
+      _         <- st.ags.update(_.focus(_.p1Filter.value).replace(v.filter.map(_.tag)))
+      _         <- st.ags.update(_.focus(_.p1FieldStop.value).replace(v.fieldStop.map(_.tag)))
+      r         <- ctr.getPwfs1Mechs
+    } yield assertEquals(r, v)
+  }
+
+  test("Get PWFS1 mechanisms state with undefined positions") {
+    val v = PwfsMechsState(none, none)
+
+    for {
+      (st, ctr) <- createController()
+      _         <- st.ags.update(_.focus(_.p1Filter.value).replace("undefined".some))
+      _         <- st.ags.update(_.focus(_.p1FieldStop.value).replace("undefined".some))
       r         <- ctr.getPwfs1Mechs
     } yield assertEquals(r, v)
   }
 
   test("Get PWFS2 mechanisms state") {
-    val v = PwfsMechsState(PwfsFilter.Red, PwfsFieldStop.Fs6_4)
+    val v = PwfsMechsState(PwfsFilter.Red.some, PwfsFieldStop.Fs6_4.some)
 
     for {
       (st, ctr) <- createController()
-      _         <- st.ags.update(_.focus(_.p2Filter.value).replace(v.filter.tag.some))
-      _         <- st.ags.update(_.focus(_.p2FieldStop.value).replace(v.fieldStop.tag.some))
+      _         <- st.ags.update(_.focus(_.p2Filter.value).replace(v.filter.map(_.tag)))
+      _         <- st.ags.update(_.focus(_.p2FieldStop.value).replace(v.fieldStop.map(_.tag)))
+      r         <- ctr.getPwfs2Mechs
+    } yield assertEquals(r, v)
+  }
+
+  test("Get PWFS2 mechanisms state with undefined positions") {
+    val v = PwfsMechsState(none, none)
+
+    for {
+      (st, ctr) <- createController()
+      _         <- st.ags.update(_.focus(_.p2Filter.value).replace("undefined".some))
+      _         <- st.ags.update(_.focus(_.p2FieldStop.value).replace("undefined".some))
       r         <- ctr.getPwfs2Mechs
     } yield assertEquals(r, v)
   }

--- a/modules/web/server/src/main/resources/navigate.graphql
+++ b/modules/web/server/src/main/resources/navigate.graphql
@@ -397,8 +397,8 @@ input AcWindowInput {
 }
 
 type AcMechs {
-    lens: AcLens!
-    filter: AcFilter!
+    lens: AcLens
+    filter: AcFilter
     ndFilter: AcNdFilter
 }
 
@@ -424,8 +424,8 @@ enum PwfsFieldStop {
 }
 
 type PwfsMechsState {
-    filter: PwfsFilter!
-    fieldStop: PwfsFieldStop!
+    filter: PwfsFilter
+    fieldStop: PwfsFieldStop
 }
 
 type Query {


### PR DESCRIPTION
AC and PWFS mechanism reported positions now are an optional value in query result. They will not be present if the position read from EPICS channels is "undefined" (which happens while the mechanism is moving between named positions)