### PR TITLE
SC-6895 Clear internal guide state on slew

### DIFF
--- a/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
+++ b/modules/server/src/main/scala/navigate/server/NavigateEngine.scala
@@ -321,6 +321,14 @@ object NavigateEngine {
             .modify[State](
               _.focus(_.onSwappedTarget).replace(false)
             )
+            .flatMap(_ =>
+              cats.data.State
+                .modify[State](
+                  _.focus(_.guideConfig.tcsGuide)
+                    .replace(GuideOff)
+                )
+                .whenA(slewOptions.stopGuide.value)
+            )
             .as(
               systems.tcsCommon
                 .slew(slewOptions, tcsConfig)
@@ -454,14 +462,7 @@ object NavigateEngine {
       cats.data.State
         .modify[State](
           _.focus(_.guideConfig.tcsGuide)
-            .replace(
-              TelescopeGuideConfig(MountGuideOption.MountGuideOff,
-                                   M1GuideConfig.M1GuideOff,
-                                   M2GuideConfig.M2GuideOff,
-                                   None,
-                                   None
-              )
-            )
+            .replace(GuideOff)
         )
         .as(
           systems.tcsCommon.disableGuide
@@ -936,5 +937,12 @@ object NavigateEngine {
         Logger[F].error(s"CommandFailure(${cmd.name}, $msg)")
       case _                                                         => Applicative[F].unit
     }
+
+  val GuideOff: TelescopeGuideConfig = TelescopeGuideConfig(MountGuideOption.MountGuideOff,
+                                                            M1GuideConfig.M1GuideOff,
+                                                            M2GuideConfig.M2GuideOff,
+                                                            none,
+                                                            none
+  )
 
 }

--- a/modules/server/src/test/scala/navigate/server/NavigateEngineSpec.scala
+++ b/modules/server/src/test/scala/navigate/server/NavigateEngineSpec.scala
@@ -11,14 +11,24 @@ import cats.effect.Resource
 import cats.syntax.all.*
 import fs2.Stream
 import lucuma.core.enums.ComaOption
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.M1Source
 import lucuma.core.enums.MountGuideOption
 import lucuma.core.enums.Site
 import lucuma.core.enums.TipTiltSource
+import lucuma.core.math.Angle
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Epoch
+import lucuma.core.math.Parallax
+import lucuma.core.math.ProperMotion
+import lucuma.core.math.RadialVelocity
+import lucuma.core.math.Wavelength
 import lucuma.core.model.M1GuideConfig
 import lucuma.core.model.M2GuideConfig.M2GuideOn
 import lucuma.core.model.TelescopeGuideConfig
 import munit.CatsEffectSuite
+import navigate.model.*
+import navigate.model.Target.SiderealTarget
 import navigate.model.config.NavigateEngineConfiguration
 import navigate.server.tcs.TcsNorthControllerSim
 import navigate.server.tcs.TcsSouthControllerSim
@@ -31,22 +41,162 @@ class NavigateEngineSpec extends CatsEffectSuite {
 
   private given Logger[IO] = Slf4jLogger.getLoggerFromName[IO]("navigate-engine")
 
+  val guideOnCfg = TelescopeGuideConfig(
+    mountGuide = MountGuideOption.MountGuideOn,
+    m1Guide = M1GuideConfig.M1GuideOn(M1Source.OIWFS),
+    m2Guide = M2GuideOn(ComaOption.ComaOn, Set(TipTiltSource.OIWFS)),
+    dayTimeMode = Some(false),
+    probeGuide = none
+  )
+
   test("NavigateEngine must memorize requested guide configuration.") {
-
-    val guideCfg = TelescopeGuideConfig(
-      mountGuide = MountGuideOption.MountGuideOn,
-      m1Guide = M1GuideConfig.M1GuideOn(M1Source.OIWFS),
-      m2Guide = M2GuideOn(ComaOption.ComaOn, Set(TipTiltSource.OIWFS)),
-      dayTimeMode = Some(false),
-      probeGuide = none
-    )
-
     for {
       eng <- NavigateEngineSpec.buildEngine[IO]
-      _   <- Stream.eval(eng.enableGuide(guideCfg)).merge(eng.eventStream.take(1)).compile.drain
+      _   <- Stream.eval(eng.enableGuide(guideOnCfg)).merge(eng.eventStream.take(1)).compile.drain
       r   <- eng.getGuideDemand
-    } yield assertEquals(r.tcsGuide, guideCfg)
+    } yield assertEquals(r.tcsGuide, guideOnCfg)
   }
+
+  val targetRa  = "17:01:00.000000"
+  val targetDec = "-21:10:59.999999"
+
+  val target = SiderealTarget(
+    objectName = "dummy",
+    wavelength = Wavelength.fromIntPicometers(400 * 1000),
+    coordinates =
+      Coordinates.fromHmsDms.getOption(s"$targetRa $targetDec").getOrElse(Coordinates.Zero),
+    epoch = Epoch.J2000,
+    properMotion = ProperMotion(ProperMotion.μasyRA(1000), ProperMotion.μasyDec(2000)).some,
+    radialVelocity = RadialVelocity.fromMetersPerSecond.getOption(BigDecimal.decimal(3000)),
+    parallax = Parallax.fromMicroarcseconds(4000).some
+  )
+
+  val pwfs1Target = SiderealTarget(
+    objectName = "pwfs1Dummy",
+    wavelength = Wavelength.fromIntPicometers(550 * 1000),
+    coordinates =
+      Coordinates.fromHmsDms.getOption("17:00:58.75 -21:10:00.5").getOrElse(Coordinates.Zero),
+    epoch = Epoch.J2000,
+    properMotion = none,
+    radialVelocity = none,
+    parallax = none
+  )
+
+  val pwfs2Target = SiderealTarget(
+    objectName = "pwfs2Dummy",
+    wavelength = Wavelength.fromIntPicometers(800 * 1000),
+    coordinates =
+      Coordinates.fromHmsDms.getOption("17:01:09.999999 -21:10:01.0").getOrElse(Coordinates.Zero),
+    epoch = Epoch.J2000,
+    properMotion = none,
+    radialVelocity = none,
+    parallax = none
+  )
+
+  val oiwfsTarget = SiderealTarget(
+    objectName = "oiwfsDummy",
+    wavelength = Wavelength.fromIntPicometers(600 * 1000),
+    coordinates = Coordinates.fromHmsDms
+      .getOption("17:00:59.999999 -21:10:00.000001")
+      .getOrElse(Coordinates.Zero),
+    epoch = Epoch.J2000,
+    properMotion = none,
+    radialVelocity = none,
+    parallax = none
+  )
+
+  val slewOptions = SlewOptions(
+    ZeroChopThrow(true),
+    ZeroSourceOffset(false),
+    ZeroSourceDiffTrack(true),
+    ZeroMountOffset(false),
+    ZeroMountDiffTrack(true),
+    ShortcircuitTargetFilter(false),
+    ShortcircuitMountFilter(true),
+    ResetPointing(false),
+    StopGuide(true),
+    ZeroGuideOffset(false),
+    ZeroInstrumentOffset(true),
+    AutoparkPwfs1(false),
+    AutoparkPwfs2(true),
+    AutoparkOiwfs(false),
+    AutoparkGems(true),
+    AutoparkAowfs(false)
+  )
+
+  val wfsTracking = TrackingConfig(true, false, false, true)
+
+  val instrumentSpecifics: InstrumentSpecifics = InstrumentSpecifics(
+    iaa = Angle.fromDoubleDegrees(123.45),
+    focusOffset = Distance.fromLongMicrometers(2344),
+    agName = "gmos",
+    origin = Origin(Angle.fromMicroarcseconds(4567), Angle.fromMicroarcseconds(-8901))
+  )
+
+  test(
+    "NavigateEngine must reset guide configuration after a slew command when slew option in on."
+  ) {
+    for {
+      eng <- NavigateEngineSpec.buildEngine[IO]
+      _   <- Stream
+               .evals(
+                 List(
+                   eng.enableGuide(guideOnCfg),
+                   eng.slew(
+                     slewOptions,
+                     TcsConfig(
+                       target,
+                       instrumentSpecifics,
+                       GuiderConfig(pwfs1Target, wfsTracking).some,
+                       GuiderConfig(pwfs2Target, wfsTracking).some,
+                       GuiderConfig(oiwfsTarget, wfsTracking).some,
+                       RotatorTrackConfig(Angle.Angle90, RotatorTrackingMode.Tracking),
+                       Instrument.GmosNorth
+                     ),
+                     none
+                   )
+                 ).sequence
+               )
+               .merge(eng.eventStream)
+               .take(4)
+               .compile
+               .drain
+      r   <- eng.getGuideDemand
+    } yield assertEquals(r.tcsGuide, NavigateEngine.GuideOff)
+  }
+
+  test(
+    "NavigateEngine must not reset guide configuration after a slew command when slew option in off."
+  ) {
+    for {
+      eng <- NavigateEngineSpec.buildEngine[IO]
+      _   <- Stream
+               .evals(
+                 List(
+                   eng.enableGuide(guideOnCfg),
+                   eng.slew(
+                     slewOptions.copy(stopGuide = StopGuide(false)),
+                     TcsConfig(
+                       target,
+                       instrumentSpecifics,
+                       GuiderConfig(pwfs1Target, wfsTracking).some,
+                       GuiderConfig(pwfs2Target, wfsTracking).some,
+                       GuiderConfig(oiwfsTarget, wfsTracking).some,
+                       RotatorTrackConfig(Angle.Angle90, RotatorTrackingMode.Tracking),
+                       Instrument.GmosNorth
+                     ),
+                     none
+                   )
+                 ).sequence
+               )
+               .merge(eng.eventStream)
+               .take(4)
+               .compile
+               .drain
+      r   <- eng.getGuideDemand
+    } yield assertEquals(r.tcsGuide, guideOnCfg)
+  }
+
 }
 
 object NavigateEngineSpec {


### PR DESCRIPTION
This fixes a bug, where after a slew with loops closed, Navigate would close loops when taking a OIWFS sky.